### PR TITLE
Fix errors on search result pages

### DIFF
--- a/components/SearchResultSpeaker.tsx
+++ b/components/SearchResultSpeaker.tsx
@@ -1,9 +1,9 @@
 import { pluralize } from '@/libs/pluralize'
 import React from 'react'
 import Link from 'next/link'
-import gql from 'graphql-tag'
+import { FragmentType, gql, useFragment } from '@/__generated__'
 
-export const SearchResultSpeakerFragment = gql`
+export const SearchResultSpeakerFragment = gql(`
   fragment SearchResultSpeakerDetail on Speaker {
     id
     fullName
@@ -13,50 +13,43 @@ export const SearchResultSpeakerFragment = gql`
     }
     verifiedStatementsCount
   }
-`
+`)
 
 export function SearchResultSpeaker(props: {
-  speaker: {
-    id: string
-    fullName: string
-    avatar: string
-    body: { shortName: string }
-    verifiedStatementsCount: number
-  }
+  speaker: FragmentType<typeof SearchResultSpeakerFragment>
 }) {
   const mediaUrl = process.env.NEXT_PUBLIC_MEDIA_URL
+
+  const speaker = useFragment(SearchResultSpeakerFragment, props.speaker)
 
   return (
     <div className="col s-speaker">
       <div className="h-100 d-flex flex-column justify-content-between align-items-center">
         <div className="w-100 p-5">
           <Link
-            href={`/politici/${props.speaker.id}`}
+            href={`/politici/${speaker.id}`}
             className="d-block position-relative"
           >
             <span className="symbol symbol-square symbol-circle">
-              {props.speaker.avatar && (
-                <img
-                  src={mediaUrl + props.speaker.avatar}
-                  alt={props.speaker.fullName}
-                />
+              {speaker.avatar && (
+                <img src={mediaUrl + speaker.avatar} alt={speaker.fullName} />
               )}
             </span>
-            {props.speaker.body && (
+            {speaker.body && (
               <div className="symbol-label d-flex align-items-center justify-content-center w-45px h-45px rounded-circle bg-dark">
                 <span className="smallest text-white lh-1 text-center p-2">
-                  {props.speaker.body.shortName}
+                  {speaker.body.shortName}
                 </span>
               </div>
             )}
           </Link>
         </div>
         <div className=" text-center lh-1">
-          <h3 className="fs-4 fw-bold mb-4">{props.speaker.fullName}</h3>
+          <h3 className="fs-4 fw-bold mb-4">{speaker.fullName}</h3>
           <p className="fs-6 fw-bold mb-4">{/*<%= speaker.role %>*/}</p>
           <p className="fs-6">
-            {`${props.speaker.verifiedStatementsCount} ${pluralize(
-              props.speaker.verifiedStatementsCount,
+            {`${speaker.verifiedStatementsCount} ${pluralize(
+              speaker.verifiedStatementsCount,
               'výrok',
               'výroky',
               'výroků'
@@ -64,10 +57,7 @@ export function SearchResultSpeaker(props: {
           </p>
         </div>
         <div className="text-center mt-4">
-          <Link
-            href={`/politici/${props.speaker.id}`}
-            className="btn outline h-40x"
-          >
+          <Link href={`/politici/${speaker.id}`} className="btn outline h-40x">
             <span className="fs-7">Otevřít profil</span>
           </Link>
         </div>

--- a/libs/query-params.tsx
+++ b/libs/query-params.tsx
@@ -10,6 +10,14 @@ export function getNumericalArrayParams(
   )
 }
 
+export function getStringParam(queryParams?: string | string[]): string {
+  if (!queryParams) {
+    return ''
+  }
+
+  return Array.isArray(queryParams) ? queryParams[0] : queryParams
+}
+
 export function getStringArrayParams(
   queryParams?: string | string[]
 ): string[] {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "generate": "npm run generate-possible-types && graphql-codegen",
+    "generate:watch": "npm run generate-possible-types && graphql-codegen --watch",
     "generate-possible-types": "node ./scripts/generate-possible-types.js"
   },
   "prettier": {

--- a/pages/vyhledavani/politici.tsx
+++ b/pages/vyhledavani/politici.tsx
@@ -1,34 +1,33 @@
 import React from 'react'
-import {
-  SearchResultSpeaker,
-  SearchResultSpeakerFragment,
-} from '@/components/SearchResultSpeaker'
+import { SearchResultSpeaker } from '@/components/SearchResultSpeaker'
 import client from '@/libs/apollo-client'
-import gql from 'graphql-tag'
 import Link from 'next/link'
 import { Pagination } from '@/components/pagination'
 import { NextPageContext } from 'next'
 import { parsePage } from '@/libs/pagination'
 import { SearchButton } from '@/components/search/SearchButton'
+import { gql } from '@/__generated__'
+import { getStringParam } from '@/libs/query-params'
+import { SearchSpeakersQuery } from '@/__generated__/graphql'
 
 const SEARCH_PAGE_SIZE = 12
 
 export async function getServerSideProps({ query }: NextPageContext) {
-  const term = query?.q ?? ''
+  const term = getStringParam(query?.q)
   const page = parsePage(query?.page)
 
   const { data: searchData } = await client.query({
-    query: gql`
+    query: gql(`
       query searchSpeakers($term: String!, $limit: Int, $offset: Int) {
         searchSpeakers(term: $term, limit: $limit, offset: $offset) {
           speakers {
+            id
             ...SearchResultSpeakerDetail
           }
           totalCount
         }
       }
-      ${SearchResultSpeakerFragment}
-    `,
+    `),
     variables: {
       term,
       limit: SEARCH_PAGE_SIZE,
@@ -48,10 +47,7 @@ export async function getServerSideProps({ query }: NextPageContext) {
 export default function SearchSpeakers(props: {
   term: string
   page: number
-  speakerSearchResult: {
-    speakers: any[]
-    totalCount: number
-  }
+  speakerSearchResult: SearchSpeakersQuery['searchSpeakers']
 }) {
   return (
     <div className="container">

--- a/pages/vyhledavani/vyroky.tsx
+++ b/pages/vyhledavani/vyroky.tsx
@@ -1,37 +1,33 @@
 import React from 'react'
-import {
-  SearchResultSpeaker,
-  SearchResultSpeakerFragment,
-} from '@/components/SearchResultSpeaker'
 import client from '@/libs/apollo-client'
-import gql from 'graphql-tag'
 import Link from 'next/link'
 import { Pagination } from '@/components/pagination'
 import { NextPageContext } from 'next'
-import StatementItem, {
-  StatementItemFragment,
-} from '@/components/statement/Item'
+import StatementItem from '@/components/statement/Item'
 import { parsePage } from '@/libs/pagination'
 import { SearchButton } from '@/components/search/SearchButton'
+import { gql } from '@/__generated__'
+import { getStringParam } from '@/libs/query-params'
+import { SearchStatementsQuery } from '@/__generated__/graphql'
 
 const SEARCH_PAGE_SIZE = 10
 
 export async function getServerSideProps({ query }: NextPageContext) {
-  const term = query?.q ?? ''
+  const term = getStringParam(query?.q)
   const page = parsePage(query?.page)
 
   const { data } = await client.query({
-    query: gql`
+    query: gql(`
       query searchStatements($term: String!, $limit: Int, $offset: Int) {
         searchStatements(term: $term, limit: $limit, offset: $offset) {
           statements {
+            id
             ...StatementDetail
           }
           totalCount
         }
       }
-      ${StatementItemFragment}
-    `,
+    `),
     variables: {
       term,
       limit: SEARCH_PAGE_SIZE,
@@ -43,7 +39,7 @@ export async function getServerSideProps({ query }: NextPageContext) {
     props: {
       term,
       page,
-      statementSearchResult: data,
+      statementSearchResult: data['searchStatements'],
     },
   }
 }
@@ -51,10 +47,7 @@ export async function getServerSideProps({ query }: NextPageContext) {
 export default function SearchSpeakers(props: {
   term: string
   page: number
-  statementSearchResult: {
-    statements: any[]
-    totalCount: number
-  }
+  statementSearchResult: SearchStatementsQuery['searchStatements']
 }) {
   return (
     <div className="container">

--- a/pages/vyhledavani/vystupy.tsx
+++ b/pages/vyhledavani/vystupy.tsx
@@ -1,31 +1,33 @@
 import React from 'react'
 import client from '@/libs/apollo-client'
-import gql from 'graphql-tag'
 import Link from 'next/link'
 import { Pagination } from '@/components/pagination'
 import { NextPageContext } from 'next'
-import ArticleItem, { ArticleDetailFragment } from '@/components/article/Item'
+import ArticleItem from '@/components/article/Item'
 import { parsePage } from '@/libs/pagination'
 import { SearchButton } from '@/components/search/SearchButton'
+import { gql } from '@/__generated__'
+import { SearchArticlesQuery } from '@/__generated__/graphql'
+import { getStringParam } from '@/libs/query-params'
 
 const SEARCH_PAGE_SIZE = 10
 
 export async function getServerSideProps({ query }: NextPageContext) {
-  const term = query?.q ?? ''
+  const term = getStringParam(query?.q)
   const page = parsePage(query?.page)
 
   const { data: searchData } = await client.query({
-    query: gql`
+    query: gql(`
       query searchArticles($term: String!, $limit: Int, $offset: Int) {
         searchArticles(term: $term, limit: $limit, offset: $offset) {
           articles {
+            id
             ...ArticleDetail
           }
           totalCount
         }
       }
-      ${ArticleDetailFragment}
-    `,
+    `),
     variables: {
       term,
       limit: SEARCH_PAGE_SIZE,
@@ -45,10 +47,7 @@ export async function getServerSideProps({ query }: NextPageContext) {
 export default function SearchArticles(props: {
   term: string
   page: number
-  articleSearchResult: {
-    articles: any[]
-    totalCount: number
-  }
+  articleSearchResult: SearchArticlesQuery['searchArticles']
 }) {
   return (
     <div className="container">


### PR DESCRIPTION
The issue was not using the use fragment and type miss-matches.

Fixed by utilizing gql from generated package and added useFragment to the speaker search result component.