### PR TITLE
Add formatting of statement counts in filter labels

### DIFF
--- a/components/filtering/ReleasedYearFilter.tsx
+++ b/components/filtering/ReleasedYearFilter.tsx
@@ -1,6 +1,6 @@
-import { pluralize } from '@/libs/pluralize'
 import classNames from 'classnames'
 import gql from 'graphql-tag'
+import { StatementCount } from './StatementCount'
 
 export type ReleasedYearAggregation = {
   year: number
@@ -31,7 +31,7 @@ export function ReleasedYearFilter({ year, count, isSelected }: Props) {
       <span className="checkmark"></span>
       <span className="small fw-600 me-2">{year}</span>
       <span className="smallest min-w-40px">
-        {count} {pluralize(count, 'výrok', 'výroky', 'výroků')}
+        <StatementCount count={count} />
       </span>
     </div>
   )

--- a/components/filtering/StatementCount.tsx
+++ b/components/filtering/StatementCount.tsx
@@ -1,0 +1,10 @@
+import { formatNumber } from '@/libs/format-number'
+import { pluralize } from '@/libs/pluralize'
+
+export function StatementCount({ count }: { count: number }) {
+  return (
+    <>
+      {formatNumber(count)} {pluralize(count, 'výrok', 'výroky', 'výroků')}
+    </>
+  )
+}

--- a/components/filtering/TagFilter.tsx
+++ b/components/filtering/TagFilter.tsx
@@ -1,5 +1,5 @@
-import { pluralize } from '@/libs/pluralize'
 import gql from 'graphql-tag'
+import { StatementCount } from './StatementCount'
 
 export type TagAggregation = {
   tag: { id: string; name: string }
@@ -32,7 +32,7 @@ export function TagFilter({ tag, count, isSelected = false }: Props) {
       <span className="checkmark" />
       <span className="small fw-600 me-2">{tag.name}</span>
       <span className="smallest min-w-40px">
-        {count} {pluralize(count, 'výrok', 'výroky', 'výroků')}
+        <StatementCount count={count} />
       </span>
     </div>
   )

--- a/components/filtering/VeracityFilter.tsx
+++ b/components/filtering/VeracityFilter.tsx
@@ -1,6 +1,6 @@
-import { pluralize } from '@/libs/pluralize'
 import classNames from 'classnames'
 import gql from 'graphql-tag'
+import { StatementCount } from './StatementCount'
 
 export type VeracityAggregation = {
   veracity: {
@@ -44,7 +44,7 @@ export function VeracityFilter({ veracity, count, isSelected }: Props) {
       <span className="checkmark"></span>
       <span className="small fw-600 me-2">{veracity.name}</span>
       <span className="smallest min-w-40px">
-        {count} {pluralize(count, 'výrok', 'výroky', 'výroků')}
+        <StatementCount count={count} />
       </span>
     </div>
   )

--- a/libs/format-number.ts
+++ b/libs/format-number.ts
@@ -1,0 +1,3 @@
+export function formatNumber(number: number) {
+  return new Intl.NumberFormat('cz-CS', { style: 'decimal' }).format(number)
+}


### PR DESCRIPTION
Uses https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat#Using_options for number formatting. Needs to be done for other filters (speakers as well).