### PR TITLE
Show text & statement segments in article detail

### DIFF
--- a/app/(admin)/admin/articles/[slug]/page.tsx
+++ b/app/(admin)/admin/articles/[slug]/page.tsx
@@ -1,12 +1,14 @@
 import { gql } from '@/__generated__'
 
 import { AdminArticleHeader } from '@/components/admin/articles/AdminArticleHeader'
+import { AdminArticleContent } from '@/components/admin/articles/AdminArticleContent'
 import { serverQuery } from '@/libs/apollo-client-server'
 
 const ArticleQuery = gql(`
   query AdminArticle($id: ID!) {
     article(id: $id, includeUnpublished: true) {
       ...AdminArticleHeader
+      ...AdminArticleContent
     }
   }
 `)
@@ -24,6 +26,7 @@ export default async function AdminArticle(props: {
   return (
     <>
       <AdminArticleHeader article={data.article} />
+      <AdminArticleContent article={data.article} />
     </>
   )
 }

--- a/assets/styles/tailwind.css
+++ b/assets/styles/tailwind.css
@@ -1,3 +1,33 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer utilities {
+  .article-content p {
+    @apply mt-8;
+  }
+
+  .article-content ul {
+    @apply mt-8 max-w-xl space-y-8 text-gray-600;
+  }
+
+  .article-content ul li {
+    list-style: inside;
+  }
+
+  .article-content h2 {
+    @apply mt-16 text-2xl font-bold tracking-tight text-gray-900;
+  }
+
+  .article-content figure {
+    @apply mt-8;
+  }
+
+  .article-content figure img {
+    @apply aspect-video rounded-xl bg-gray-50 object-cover;
+  }
+
+  .article-content figcaption {
+    @apply mt-4 flex gap-x-2 text-sm leading-6 text-gray-500;
+  }
+}

--- a/components/admin/articles/AdminArticleContent.tsx
+++ b/components/admin/articles/AdminArticleContent.tsx
@@ -1,0 +1,70 @@
+import { gql, FragmentType, useFragment } from '@/__generated__'
+import { InformationCircleIcon } from '@heroicons/react/20/solid'
+import { AdminStatement } from './segments/AdminStatement'
+
+const AdminArticleContentFragment = gql(`
+  fragment AdminArticleContent on Article {
+    title
+    perex
+    illustration
+    segments {
+      id
+      segmentType
+      textHtml
+      statements {
+        id
+        ...AdminStatement 
+      }
+    }
+  }
+`)
+
+export function AdminArticleContent(props: {
+  article: FragmentType<typeof AdminArticleContentFragment>
+}) {
+  const article = useFragment(AdminArticleContentFragment, props.article)
+  const mediaUrl = process.env.NEXT_PUBLIC_MEDIA_URL ?? ''
+
+  return (
+    <div className="bg-white p-6 p-6 lg:px-0">
+      <div className="max-w-3xl text-base leading-7 text-gray-700">
+        <p className="mt-0 text-xl leading-8">{article.perex}</p>
+        {article.illustration && (
+          <figure className="mt-10">
+            <img
+              alt={article.title}
+              src={mediaUrl + article.illustration}
+              className="aspect-video rounded-xl bg-gray-50 object-cover"
+            />
+            <figcaption className="mt-4 flex gap-x-2 text-sm leading-6 text-gray-500">
+              <InformationCircleIcon
+                aria-hidden="true"
+                className="mt-0.5 h-5 w-5 flex-none text-gray-300"
+              />
+              Ilustrační obrázek k {article.title}
+            </figcaption>
+          </figure>
+        )}
+
+        {article.segments.map((segment) =>
+          segment.segmentType === 'text' ? (
+            <div
+              key={segment.id}
+              className="mt-10 max-w-2xl article-content"
+              dangerouslySetInnerHTML={{ __html: segment.textHtml ?? '' }}
+            ></div>
+          ) : (
+            <div
+              key={segment.id}
+              className="mt-10 max-w-2xl divide-y divide-gray-100 px-4 py-5"
+            >
+              {segment.statements.map((statement) => (
+                <AdminStatement key={statement.id} statement={statement} />
+              ))}
+            </div>
+          )
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/admin/articles/segments/AdminStatement.tsx
+++ b/components/admin/articles/segments/AdminStatement.tsx
@@ -61,13 +61,13 @@ export function AdminStatement(props: {
           </div>
         </div>
       </div>
-      <div>
-        <p className="mt-1 text-base italic text-gray-600">
+      <div className="space-y-4">
+        <p className="text-base italic text-gray-600">
           &bdquo;{statement.content}&rdquo;
         </p>
         <span
           className={classNames(
-            'mt-1 inline-flex items-center rounded-md px-2 py-1 text-xs font-medium',
+            'inline-flex items-center rounded-md px-2 py-1 text-xs font-medium',
             {
               'bg-green-100 text-green-700':
                 statement.assessment.veracity?.key === 'true',
@@ -82,7 +82,7 @@ export function AdminStatement(props: {
         >
           {statement.assessment?.veracity?.name}
         </span>
-        <p className="mt-1 text-sm text-gray-500">
+        <p className="text-sm text-gray-500">
           {statement.assessment?.shortExplanation}
         </p>
       </div>


### PR DESCRIPTION
Rendering of text segments and source statements in article detail.

<img width="1623" alt="Screenshot 2024-09-27 at 13 11 13" src="https://github.com/user-attachments/assets/875f54f5-18d1-4b83-aa99-845b2eaf02f8">
<img width="1623" alt="Screenshot 2024-09-27 at 13 11 34" src="https://github.com/user-attachments/assets/09e88d63-a100-4f30-851b-a6b99e20a71a">


Close #170
Close #171
Close #224