### PR TITLE
Embedding statements kick-off

### DIFF
--- a/app/(admin)/beta/admin/articles/[slug]/edit/page.tsx
+++ b/app/(admin)/beta/admin/articles/[slug]/edit/page.tsx
@@ -6,6 +6,8 @@ import { updateArticle, updateArticleSingleStatement } from '../../actions'
 import { ArticleTypeEnum } from '@/__generated__/graphql'
 import { Metadata } from 'next'
 import { getMetadataTitle } from '@/libs/metadata'
+import { PropsWithSearchParams } from '@/libs/params'
+import { getBooleanParam } from '@/libs/query-params'
 
 export async function generateMetadata(props: {
   params: { slug: string }
@@ -30,9 +32,11 @@ export async function generateMetadata(props: {
   }
 }
 
-export default async function AdminArticleEdit(props: {
-  params: { slug: string }
-}) {
+export default async function AdminArticleEdit(
+  props: PropsWithSearchParams<{
+    params: { slug: string }
+  }>
+) {
   const { data } = await serverQuery({
     query: gql(`
       query AdminArticleEdit($id: ID!) {
@@ -50,6 +54,11 @@ export default async function AdminArticleEdit(props: {
     },
   })
 
+  // TODO: Remove once the embedding statements is launched
+  const allowEmbeddingStatements = getBooleanParam(
+    props.searchParams.embedStatements
+  )
+
   if (data.article?.articleType === ArticleTypeEnum.SingleStatement) {
     return (
       <AdminArticleSingleStatementForm
@@ -66,6 +75,7 @@ export default async function AdminArticleEdit(props: {
       data={data}
       article={data.article}
       action={updateArticle.bind(null, data.article.id)}
+      allowEmbeddingStatements={allowEmbeddingStatements}
     />
   )
 }

--- a/app/(admin)/beta/admin/articles/new/page.tsx
+++ b/app/(admin)/beta/admin/articles/new/page.tsx
@@ -5,12 +5,14 @@ import { gql } from '@/__generated__'
 import { serverQuery } from '@/libs/apollo-client-server'
 import { AdminArticleForm } from '@/components/admin/articles/AdminArticleForm'
 import { createArticle } from '@/app/(admin)/beta/admin/articles/actions'
+import { PropsWithSearchParams } from '@/libs/params'
+import { getBooleanParam } from '@/libs/query-params'
 
 export const metadata: Metadata = {
   title: getMetadataTitle('Nový článek', 'Administrace'),
 }
 
-export default async function AdminArticleNew() {
+export default async function AdminArticleNew(props: PropsWithSearchParams) {
   const { data } = await serverQuery({
     query: gql(`
       query AdminArticleNew {
@@ -19,12 +21,18 @@ export default async function AdminArticleNew() {
   `),
   })
 
+  // TODO: Remove once the embedding statements is launched
+  const allowEmbeddingStatements = getBooleanParam(
+    props.searchParams.embedStatements
+  )
+
   return (
     <AdminArticleForm
       title="Nový článek"
       description="Vytvořte nový článek"
       data={data}
       action={createArticle}
+      allowEmbeddingStatements={allowEmbeddingStatements}
     />
   )
 }

--- a/components/admin/articles/AdminArticleForm.tsx
+++ b/components/admin/articles/AdminArticleForm.tsx
@@ -193,6 +193,8 @@ export function AdminArticleForm(props: {
   data: FragmentType<typeof AdminArticleFormFragment>
   article?: FragmentType<typeof AdminArticleFormFieldsFragment>
   action(prevState: FormState, input: FormData): Promise<FormState>
+  // TODO: Remove once the experiment is launched
+  allowEmbeddingStatements?: boolean
 }) {
   const [state, formAction] = useFormState(props.action, { message: '' })
   const data = useFragment(AdminArticleFormFragment, props.data)
@@ -321,6 +323,7 @@ export function AdminArticleForm(props: {
                           />
                           <RichTextEditor
                             includeHeadings
+                            includeStatements={props.allowEmbeddingStatements}
                             value={field.value}
                             onChange={field.onChange}
                           />

--- a/components/admin/forms/RichTextEditor.tsx
+++ b/components/admin/forms/RichTextEditor.tsx
@@ -28,17 +28,21 @@ import {
 import { Embed } from '@/libs/ck-plugins/embed'
 
 import 'ckeditor5/ckeditor5.css'
+import { StatementEmbed } from '@/libs/ck-plugins/embed-statement'
 
 export default function RickTextEditor(props: {
-  includeHeadings: boolean
+  includeHeadings?: boolean
+  includeStatements?: boolean
   value: string
   onChange(value: string): void
 }) {
+  const { onChange } = props
+
   const handleChange = useCallback(
     (_: EventInfo, editor: Editor) => {
-      props.onChange(editor.getData())
+      onChange(editor.getData())
     },
-    [props.onChange]
+    [onChange]
   )
 
   const config = useMemo(() => {
@@ -59,11 +63,12 @@ export default function RickTextEditor(props: {
           '|',
           'link',
           '|',
-          'bullettedList',
+          'bulletedList',
           'numberedList',
           '|',
           'embed',
           'insertImageViaUrl',
+          ...(props.includeStatements ? ['statementEmbed'] : []),
           '|',
           'specialCharacters',
           '|',
@@ -91,6 +96,7 @@ export default function RickTextEditor(props: {
         SpecialCharacters,
         SpecialCharactersEssentials,
         SpecialCharactersSpaces,
+        StatementEmbed,
         TextTransformation,
         NonBreakableSpaceKeystrokes,
       ],

--- a/libs/ck-plugins/embed-statement.ts
+++ b/libs/ck-plugins/embed-statement.ts
@@ -1,0 +1,148 @@
+import { ButtonView, toWidget, type Editor } from 'ckeditor5'
+
+import '@ckeditor/ckeditor5-media-embed/theme/mediaembed.css'
+
+export function StatementEmbed(editor: Editor) {
+  const schema = editor.model.schema
+  const conversion = editor.conversion
+  const domConverter = editor.editing.view.domConverter
+
+  // Configure the schema.
+  schema.register('statementEmbed', {
+    isObject: true,
+    isBlock: true,
+    allowWhere: '$block',
+    allowAttributes: ['code'],
+  })
+
+  // Model -> Data
+  // conversion.for('dataDowncast').elementToElement({
+  //   model: 'embed',
+  //   view: (modelElement, { writer }) => {
+  //     const code = modelElement.getAttribute('code')
+  //
+  //     return writer.createUIElement(
+  //       'figure',
+  //       { class: 'embed' },
+  //       function (domDocument) {
+  //         const domElement = this.toDomElement(domDocument)
+  //
+  //         domElement.innerHTML = code as string
+  //
+  //         return domElement
+  //       }
+  //     )
+  //   },
+  // })
+
+  // Model -> View
+  // conversion.for('editingDowncast').elementToElement({
+  //   model: 'embed',
+  //   view: (modelElement, { writer }) => {
+  //     const code = modelElement.getAttribute('code')
+  //
+  //     const iframeWrapperElement = writer.createRawElement(
+  //       'div',
+  //       {
+  //         class: 'ck-media__wrapper',
+  //       },
+  //       (domElement: HTMLElement) => {
+  //         domElement.innerHTML = code as string
+  //       }
+  //     )
+  //
+  //     const figureElement = writer.createContainerElement('figure', {
+  //       class: 'media',
+  //     })
+  //
+  //     writer.insert(
+  //       writer.createPositionAt(figureElement, 0),
+  //       iframeWrapperElement
+  //     )
+  //
+  //     return toWidget(figureElement, writer, { label: 'embed widget' })
+  //   },
+  // })
+
+  // View -> Model
+  // conversion
+  //   .for('upcast')
+  //   // figure.embed (Preferred way to represent embed)
+  //   .elementToElement({
+  //     view: {
+  //       name: 'figure',
+  //       attributes: {
+  //         class: 'embed',
+  //       },
+  //     },
+  //     model: (viewFigure, { writer }) => {
+  //       const figureEl = domConverter.viewToDom(viewFigure)
+  //       const code = figureEl.innerHTML
+  //
+  //       return writer.createElement('embed', { code })
+  //     },
+  //   })
+  //   // iframe (To be able to parse older representation)
+  //   .elementToElement({
+  //     view: {
+  //       name: 'iframe',
+  //     },
+  //     model: (viewIframe, { writer }) => {
+  //       const iframeEl = domConverter.viewToDom(viewIframe)
+  //       const code = iframeEl.outerHTML
+  //
+  //       return writer.createElement('embed', { code })
+  //     },
+  //   })
+  //   // div.infogram-embed (To be able to parse older representation)
+  //   .elementToElement({
+  //     view: {
+  //       name: 'div',
+  //     },
+  //     model: (viewIframe, { writer }) => {
+  //       const divEl = domConverter.viewToDom(viewIframe)
+  //
+  //       if (divEl.querySelector('.infogram-embed')) {
+  //         const code = divEl.outerHTML
+  //
+  //         return writer.createElement('embed', { code })
+  //       }
+  //
+  //       return null
+  //     },
+  //   })
+
+  editor.ui.componentFactory.add('statementEmbed', (locale) => {
+    const view = new ButtonView(locale)
+
+    view.set({
+      label: 'Vložit výrok',
+      tooltip: true,
+      withText: true,
+    })
+
+    // Callback executed once the toolbar item is clicked.
+    view.on('execute', () => {
+      const code = prompt('Vložte ID výroku:')
+
+      if (code === null || code.trim() === '') {
+        // Prompt cancelled or nothing put in
+        return
+      }
+
+      editor.model.change((writer) => {
+        const embedElement = writer.createElement('statementEmbed', {
+          code,
+        })
+
+        // Insert the embed in the current selection location.
+        editor.model.insertContent(
+          embedElement,
+          editor.model.document.selection
+        )
+      })
+    })
+
+    return view
+  })
+}


### PR DESCRIPTION
Added new custom plugin for embedding statements to the text content.

The plugin is hidden to the Demagog team for now. It's possible to test it by adding `?embedStatements=true` query parameter on the new article page and edit article page.

Once we are happy with the plugin, we'll remove the conditions and make it available for anyone in the team.