### PR TITLE
Use source speakers from source

### DIFF
--- a/components/article/ArticleV2Preview.tsx
+++ b/components/article/ArticleV2Preview.tsx
@@ -6,10 +6,10 @@ export const ArticleV2PreviewFragment = gql(`
     fragment ArticleV2PreviewFragment on ArticleV2 {
         __typename
         ... on SingleStatementArticle {
-            ...SingleStatementArticlePreviewFragment
+          ...SingleStatementArticlePreviewFragment
         }
         ... on Article {
-            ...ArticleDetail
+          ...ArticleDetail
         }
     }
 `)

--- a/components/article/Item.tsx
+++ b/components/article/Item.tsx
@@ -14,16 +14,16 @@ export const ArticleDetailFragment = gql(`
     illustration(size: medium)
     title
     pinned
-    speakers {
-      id
-      ...ArticleSpeakerDetail
-    }
     articleType
     source {
       medium {
         name
       }
       releasedAt
+      sourceSpeakers {
+        id
+        ...ArticleSpeakerDetail
+      }
     }
     publishedAt
     ...ArticleLink
@@ -57,7 +57,7 @@ export default function ArticleItem(props: {
           </div>
           <div className="d-flex justify-content-between align-items-center mt-2">
             <div className="symbol-group">
-              {article.speakers?.map((speaker) => (
+              {article.source?.sourceSpeakers?.map((speaker) => (
                 <Speaker key={speaker.id} speaker={speaker} />
               ))}
             </div>


### PR DESCRIPTION
Should speed up the website. We are in a risk of a bug when showing speakers without any statements.