### PR TITLE
Remove old way of submitting forms

### DIFF
--- a/components/admin/articles/AdminArticleForm.tsx
+++ b/components/admin/articles/AdminArticleForm.tsx
@@ -26,7 +26,6 @@ import { Input } from '@/components/admin/forms/Input'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { schema } from '@/libs/articles/schema'
-import { useRef } from 'react'
 import { useFormState } from 'react-dom'
 import { AdminSourcesList } from '@/components/admin/articles/AdminSourcesList'
 import { ApolloProvider } from '@apollo/client'
@@ -45,12 +44,11 @@ import { AdminPageTitle } from '@/components/admin/layout/AdminPageTitle'
 import { AdminFormHeader } from '@/components/admin/layout/AdminFormHeader'
 import { AdminFormActions } from '../layout/AdminFormActions'
 import { AdminFormContent } from '@/components/admin/layout/AdminFormContent'
-import { useFormSubmit } from '@/libs/forms/hooks/form-submit-hook'
+import { useFormSubmitV2 } from '@/libs/forms/hooks/form-submit-hook'
 import { Textarea } from '@/components/admin/forms/Textarea'
 import { dateInputFormat } from '@/libs/date-time'
 import { FormAction } from '@/libs/forms/form-action'
 import { useFormToasts } from '@/components/admin/forms/hooks/use-form-toasts'
-import { ErrorMessage } from '@/components/admin/forms/ErrorMessage'
 
 const RichTextEditor = dynamic(
   () => import('@/components/admin/forms/RichTextEditor'),
@@ -208,9 +206,9 @@ export function AdminArticleForm(props: {
   const {
     register,
     watch,
-    handleSubmit,
+    trigger,
     control,
-    formState: { isSubmitting },
+    formState: { isValid },
   } = useForm<z.output<typeof schema>>({
     resolver: zodResolver(schema),
     defaultValues: {
@@ -224,21 +222,15 @@ export function AdminArticleForm(props: {
     name: 'segments',
   })
 
-  const formRef = useRef<HTMLFormElement>(null)
-
   const selectedArticleType = watch(
     'articleType',
     article ? toArticleTypeEnum(article.articleType) : ArticleTypeEnum.Default
   )
 
-  const { handleSubmitForm } = useFormSubmit<z.output<typeof schema>>(
-    handleSubmit,
-    formAction,
-    formRef
-  )
+  const { handleSubmitForm } = useFormSubmitV2(isValid, trigger)
 
   return (
-    <form ref={formRef} onSubmit={handleSubmitForm}>
+    <form action={formAction} onSubmit={handleSubmitForm}>
       <div className="container">
         <AdminFormHeader>
           <AdminPageTitle title={props.title} description={props.description} />

--- a/components/admin/articles/AdminArticleForm.tsx
+++ b/components/admin/articles/AdminArticleForm.tsx
@@ -44,7 +44,7 @@ import { AdminPageTitle } from '@/components/admin/layout/AdminPageTitle'
 import { AdminFormHeader } from '@/components/admin/layout/AdminFormHeader'
 import { AdminFormActions } from '../layout/AdminFormActions'
 import { AdminFormContent } from '@/components/admin/layout/AdminFormContent'
-import { useFormSubmitV2 } from '@/libs/forms/hooks/form-submit-hook'
+import { useFormSubmit } from '@/libs/forms/hooks/form-submit-hook'
 import { Textarea } from '@/components/admin/forms/Textarea'
 import { dateInputFormat } from '@/libs/date-time'
 import { FormAction } from '@/libs/forms/form-action'
@@ -227,7 +227,7 @@ export function AdminArticleForm(props: {
     article ? toArticleTypeEnum(article.articleType) : ArticleTypeEnum.Default
   )
 
-  const { handleSubmitForm } = useFormSubmitV2(isValid, trigger)
+  const { handleSubmitForm } = useFormSubmit(isValid, trigger)
 
   return (
     <form action={formAction} onSubmit={handleSubmitForm}>

--- a/components/admin/articles/AdminArticleSingleStatementForm.tsx
+++ b/components/admin/articles/AdminArticleSingleStatementForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import { useFormState } from 'react-dom'
 import { singleStatementArticleSchema } from '@/libs/articles/schema'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -19,7 +19,7 @@ import { LinkButton } from '@/components/admin/forms/LinkButton'
 import { AdminPageTitle } from '@/components/admin/layout/AdminPageTitle'
 import { AdminFormHeader } from '@/components/admin/layout/AdminFormHeader'
 import { AdminFormActions } from '../layout/AdminFormActions'
-import { useFormSubmit } from '@/libs/forms/hooks/form-submit-hook'
+import { useFormSubmitV2 } from '@/libs/forms/hooks/form-submit-hook'
 import { dateInputFormat } from '@/libs/date-time'
 import { useFormToasts } from '@/components/admin/forms/hooks/use-form-toasts'
 import { FormAction } from '@/libs/forms/form-action'
@@ -55,9 +55,13 @@ export function AdminArticleSingleStatementForm(props: {
     props.article
   )
 
-  const { register, handleSubmit, control, setValue } = useForm<
-    z.output<typeof singleStatementArticleSchema>
-  >({
+  const {
+    register,
+    trigger,
+    control,
+    setValue,
+    formState: { isValid },
+  } = useForm<z.output<typeof singleStatementArticleSchema>>({
     resolver: zodResolver(singleStatementArticleSchema),
     defaultValues: {
       title: article?.title ?? '',
@@ -69,15 +73,11 @@ export function AdminArticleSingleStatementForm(props: {
     },
   })
 
-  const formRef = useRef<HTMLFormElement>(null)
-
-  const { handleSubmitForm } = useFormSubmit<
-    z.output<typeof singleStatementArticleSchema>
-  >(handleSubmit, formAction, formRef)
+  const { handleSubmitForm } = useFormSubmitV2(isValid, trigger)
 
   return (
     <>
-      <form ref={formRef} onSubmit={handleSubmitForm}>
+      <form action={formAction} onSubmit={handleSubmitForm}>
         <div className="container">
           <AdminFormHeader>
             <AdminPageTitle

--- a/components/admin/articles/AdminArticleSingleStatementForm.tsx
+++ b/components/admin/articles/AdminArticleSingleStatementForm.tsx
@@ -19,7 +19,7 @@ import { LinkButton } from '@/components/admin/forms/LinkButton'
 import { AdminPageTitle } from '@/components/admin/layout/AdminPageTitle'
 import { AdminFormHeader } from '@/components/admin/layout/AdminFormHeader'
 import { AdminFormActions } from '../layout/AdminFormActions'
-import { useFormSubmitV2 } from '@/libs/forms/hooks/form-submit-hook'
+import { useFormSubmit } from '@/libs/forms/hooks/form-submit-hook'
 import { dateInputFormat } from '@/libs/date-time'
 import { useFormToasts } from '@/components/admin/forms/hooks/use-form-toasts'
 import { FormAction } from '@/libs/forms/form-action'
@@ -73,7 +73,7 @@ export function AdminArticleSingleStatementForm(props: {
     },
   })
 
-  const { handleSubmitForm } = useFormSubmitV2(isValid, trigger)
+  const { handleSubmitForm } = useFormSubmit(isValid, trigger)
 
   return (
     <>

--- a/components/admin/images/AdminImageForm.tsx
+++ b/components/admin/images/AdminImageForm.tsx
@@ -13,7 +13,7 @@ import { AdminFormHeader } from '../layout/AdminFormHeader'
 import { AdminPageTitle } from '../layout/AdminPageTitle'
 import { AdminFormContent } from '../layout/AdminFormContent'
 import { AdminFormActions } from '../layout/AdminFormActions'
-import { useFormSubmitV2 } from '@/libs/forms/hooks/form-submit-hook'
+import { useFormSubmit } from '@/libs/forms/hooks/form-submit-hook'
 import { FormState } from '@/libs/forms/form-state'
 import { ErrorMessage } from '@/components/admin/forms/ErrorMessage'
 
@@ -35,7 +35,7 @@ export function AdminImageForm(props: {
 
   const formRef = useRef<HTMLFormElement>(null)
 
-  const { handleSubmitForm } = useFormSubmitV2(isValid, trigger)
+  const { handleSubmitForm } = useFormSubmit(isValid, trigger)
 
   return (
     <form action={formAction} onSubmit={handleSubmitForm}>

--- a/components/admin/images/AdminImageForm.tsx
+++ b/components/admin/images/AdminImageForm.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import React, { useRef } from 'react'
 import { useFormState } from 'react-dom'
 import { useForm } from 'react-hook-form'
-import { z } from 'zod'
+import { isValid, z } from 'zod'
 import { LinkButton } from '../forms/LinkButton'
 import { SubmitButton } from '../forms/SubmitButton'
 import { contentImageSchema } from '@/libs/images/schema'
@@ -13,7 +13,7 @@ import { AdminFormHeader } from '../layout/AdminFormHeader'
 import { AdminPageTitle } from '../layout/AdminPageTitle'
 import { AdminFormContent } from '../layout/AdminFormContent'
 import { AdminFormActions } from '../layout/AdminFormActions'
-import { useFormSubmit } from '@/libs/forms/hooks/form-submit-hook'
+import { useFormSubmitV2 } from '@/libs/forms/hooks/form-submit-hook'
 import { FormState } from '@/libs/forms/form-state'
 import { ErrorMessage } from '@/components/admin/forms/ErrorMessage'
 
@@ -26,8 +26,8 @@ export function AdminImageForm(props: {
 
   const {
     control,
-    handleSubmit,
-    formState: { errors },
+    trigger,
+    formState: { errors, isValid },
   } = useForm<z.output<typeof contentImageSchema>>({
     resolver: zodResolver(contentImageSchema),
     defaultValues: {},
@@ -35,12 +35,10 @@ export function AdminImageForm(props: {
 
   const formRef = useRef<HTMLFormElement>(null)
 
-  const { handleSubmitForm } = useFormSubmit<
-    z.output<typeof contentImageSchema>
-  >(handleSubmit, formAction, formRef)
+  const { handleSubmitForm } = useFormSubmitV2(isValid, trigger)
 
   return (
-    <form ref={formRef} onSubmit={handleSubmitForm}>
+    <form action={formAction} onSubmit={handleSubmitForm}>
       <div className="container">
         <AdminFormHeader>
           <AdminPageTitle title={props.title} description={props.description} />

--- a/components/admin/media-personalities/AdminMediaPersonalitiesForm.tsx
+++ b/components/admin/media-personalities/AdminMediaPersonalitiesForm.tsx
@@ -11,7 +11,7 @@ import { FormAction } from '@/libs/forms/form-action'
 import { useFormState } from 'react-dom'
 import type { FormState } from '@/libs/forms/form-state'
 import { useFormToasts } from '@/components/admin/forms/hooks/use-form-toasts'
-import { useFormSubmitV2 } from '@/libs/forms/hooks/form-submit-hook'
+import { useFormSubmit } from '@/libs/forms/hooks/form-submit-hook'
 import { z } from 'zod'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -38,7 +38,7 @@ export default function AdminMediaPersonalitiesForm(props: {
 
   useFormToasts(state)
 
-  const { handleSubmitForm } = useFormSubmitV2(isValid, trigger)
+  const { handleSubmitForm } = useFormSubmit(isValid, trigger)
 
   return (
     <form action={formAction} onSubmit={handleSubmitForm}>

--- a/components/admin/media-personalities/AdminMediaPersonalitiesForm.tsx
+++ b/components/admin/media-personalities/AdminMediaPersonalitiesForm.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useRef } from 'react'
 import { Input } from '../forms/Input'
 import { SubmitButton } from '../forms/SubmitButton'
 import { LinkButton } from '../forms/LinkButton'
@@ -12,7 +11,7 @@ import { FormAction } from '@/libs/forms/form-action'
 import { useFormState } from 'react-dom'
 import type { FormState } from '@/libs/forms/form-state'
 import { useFormToasts } from '@/components/admin/forms/hooks/use-form-toasts'
-import { useFormSubmit } from '@/libs/forms/hooks/form-submit-hook'
+import { useFormSubmitV2 } from '@/libs/forms/hooks/form-submit-hook'
 import { z } from 'zod'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -29,9 +28,9 @@ export default function AdminMediaPersonalitiesForm(props: {
   })
 
   const {
-    handleSubmit,
+    trigger,
     register,
-    formState: { errors },
+    formState: { errors, isValid },
   } = useForm<z.output<typeof mediaPersonalitySchema>>({
     resolver: zodResolver(mediaPersonalitySchema),
     defaultValues: {},
@@ -39,11 +38,7 @@ export default function AdminMediaPersonalitiesForm(props: {
 
   useFormToasts(state)
 
-  const formRef = useRef<HTMLFormElement>(null)
-
-  const { handleSubmitForm } = useFormSubmit<
-    z.output<typeof mediaPersonalitySchema>
-  >(handleSubmit, formAction, formRef)
+  const { handleSubmitForm } = useFormSubmitV2(isValid, trigger)
 
   return (
     <form action={formAction} onSubmit={handleSubmitForm}>

--- a/components/admin/media/AdminMediumForm.tsx
+++ b/components/admin/media/AdminMediumForm.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useRef } from 'react'
 import { Input } from '../forms/Input'
 import { SubmitButton } from '../forms/SubmitButton'
 import { LinkButton } from '../forms/LinkButton'
@@ -13,11 +12,10 @@ import { useFormState } from 'react-dom'
 import type { FormState } from '@/libs/forms/form-state'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
-import { mediaPersonalitySchema } from '@/libs/media-personality/media-personality-schema'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { mediumSchema } from '@/libs/media/medium-schema'
 import { useFormToasts } from '@/components/admin/forms/hooks/use-form-toasts'
-import { useFormSubmit } from '@/libs/forms/hooks/form-submit-hook'
+import { useFormSubmitV2 } from '@/libs/forms/hooks/form-submit-hook'
 import { ErrorMessage } from '@/components/admin/forms/ErrorMessage'
 
 export default function AdminMediumForm(props: {
@@ -30,9 +28,9 @@ export default function AdminMediumForm(props: {
   })
 
   const {
-    handleSubmit,
+    trigger,
     register,
-    formState: { errors },
+    formState: { errors, isValid },
   } = useForm<z.output<typeof mediumSchema>>({
     resolver: zodResolver(mediumSchema),
     defaultValues: {},
@@ -40,11 +38,7 @@ export default function AdminMediumForm(props: {
 
   useFormToasts(state)
 
-  const formRef = useRef<HTMLFormElement>(null)
-
-  const { handleSubmitForm } = useFormSubmit<
-    z.output<typeof mediaPersonalitySchema>
-  >(handleSubmit, formAction, formRef)
+  const { handleSubmitForm } = useFormSubmitV2(isValid, trigger)
 
   return (
     <form action={formAction} onSubmit={handleSubmitForm}>

--- a/components/admin/media/AdminMediumForm.tsx
+++ b/components/admin/media/AdminMediumForm.tsx
@@ -15,7 +15,7 @@ import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { mediumSchema } from '@/libs/media/medium-schema'
 import { useFormToasts } from '@/components/admin/forms/hooks/use-form-toasts'
-import { useFormSubmitV2 } from '@/libs/forms/hooks/form-submit-hook'
+import { useFormSubmit } from '@/libs/forms/hooks/form-submit-hook'
 import { ErrorMessage } from '@/components/admin/forms/ErrorMessage'
 
 export default function AdminMediumForm(props: {
@@ -38,7 +38,7 @@ export default function AdminMediumForm(props: {
 
   useFormToasts(state)
 
-  const { handleSubmitForm } = useFormSubmitV2(isValid, trigger)
+  const { handleSubmitForm } = useFormSubmit(isValid, trigger)
 
   return (
     <form action={formAction} onSubmit={handleSubmitForm}>

--- a/components/admin/sources/AdminSourceForm.tsx
+++ b/components/admin/sources/AdminSourceForm.tsx
@@ -11,7 +11,7 @@ import { useFormState } from 'react-dom'
 import { Controller, useFieldArray, useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useFormSubmitV2 } from '@/libs/forms/hooks/form-submit-hook'
+import { useFormSubmit } from '@/libs/forms/hooks/form-submit-hook'
 import { sourceSchema } from '@/libs/sources/source-schema'
 import { Button, Description, Field, Fieldset, Legend } from '@headlessui/react'
 import { Label } from '@/components/admin/forms/Label'
@@ -126,7 +126,7 @@ export function AdminSourceForm(props: {
     name: 'sourceSpeakers',
   })
 
-  const { handleSubmitForm } = useFormSubmitV2(isValid, trigger)
+  const { handleSubmitForm } = useFormSubmit(isValid, trigger)
 
   return (
     <form action={formAction} onSubmit={handleSubmitForm}>

--- a/components/admin/sources/AdminSourceForm.tsx
+++ b/components/admin/sources/AdminSourceForm.tsx
@@ -11,8 +11,7 @@ import { useFormState } from 'react-dom'
 import { Controller, useFieldArray, useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useRef } from 'react'
-import { useFormSubmit } from '@/libs/forms/hooks/form-submit-hook'
+import { useFormSubmitV2 } from '@/libs/forms/hooks/form-submit-hook'
 import { sourceSchema } from '@/libs/sources/source-schema'
 import { Button, Description, Field, Fieldset, Legend } from '@headlessui/react'
 import { Label } from '@/components/admin/forms/Label'
@@ -90,8 +89,8 @@ export function AdminSourceForm(props: {
 
   const {
     control,
-    handleSubmit,
-    formState: { errors },
+    trigger,
+    formState: { errors, isValid },
     register,
   } = useForm<FieldValues>({
     resolver: zodResolver(sourceSchema),
@@ -127,16 +126,10 @@ export function AdminSourceForm(props: {
     name: 'sourceSpeakers',
   })
 
-  const formRef = useRef<HTMLFormElement>(null)
-
-  const { handleSubmitForm } = useFormSubmit<FieldValues>(
-    handleSubmit,
-    formAction,
-    formRef
-  )
+  const { handleSubmitForm } = useFormSubmitV2(isValid, trigger)
 
   return (
-    <form ref={formRef} onSubmit={handleSubmitForm}>
+    <form action={formAction} onSubmit={handleSubmitForm}>
       <div className="container">
         <AdminFormHeader>
           <AdminPageTitle title={props.title} description={props.description} />

--- a/components/admin/sources/statements/AdminAssessmentForm.tsx
+++ b/components/admin/sources/statements/AdminAssessmentForm.tsx
@@ -7,7 +7,7 @@ import { machine } from '@/libs/sources/machines/assessment-process-machine'
 import { useMachine } from '@xstate/react'
 import React, { useMemo } from 'react'
 import { useFormState } from 'react-dom'
-import { useFormSubmitV2 } from '@/libs/forms/hooks/form-submit-hook'
+import { useFormSubmit } from '@/libs/forms/hooks/form-submit-hook'
 import { FormAction } from '@/libs/forms/form-action'
 import { z } from 'zod'
 import { assessmentSchema } from '@/libs/sources/statement-schema'
@@ -192,7 +192,7 @@ export function AdminAssessmentForm(props: {
 
   const shortExplanation = watch('shortExplanation')
 
-  const { handleSubmitForm } = useFormSubmitV2(isValid, trigger)
+  const { handleSubmitForm } = useFormSubmit(isValid, trigger)
 
   const isStatementFieldDisabled =
     state.matches({

--- a/components/admin/sources/statements/AdminAssessmentForm.tsx
+++ b/components/admin/sources/statements/AdminAssessmentForm.tsx
@@ -239,7 +239,7 @@ export function AdminAssessmentForm(props: {
   }, [state, statement.sourceSpeaker.fullName])
 
   return (
-    <form action={formAction} onSubmit={handleSubmitForm}>
+    <form onSubmit={handleSubmitForm}>
       <input type="hidden" {...register('statementType')} />
 
       <div className="container">

--- a/components/admin/sources/statements/AdminStatementForm.tsx
+++ b/components/admin/sources/statements/AdminStatementForm.tsx
@@ -11,7 +11,7 @@ import { useFormState } from 'react-dom'
 import { Controller, useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useFormSubmitV2 } from '@/libs/forms/hooks/form-submit-hook'
+import { useFormSubmit } from '@/libs/forms/hooks/form-submit-hook'
 import { Field, Fieldset, Legend } from '@headlessui/react'
 import { Label } from '@/components/admin/forms/Label'
 import { ErrorMessage } from '@/components/admin/forms/ErrorMessage'
@@ -73,7 +73,7 @@ export function AdminStatementForm(props: {
     },
   })
 
-  const { handleSubmitForm } = useFormSubmitV2(isValid, trigger)
+  const { handleSubmitForm } = useFormSubmit(isValid, trigger)
 
   return (
     <form action={formAction} onSubmit={handleSubmitForm}>

--- a/components/admin/sources/statements/AdminStatementForm.tsx
+++ b/components/admin/sources/statements/AdminStatementForm.tsx
@@ -11,8 +11,7 @@ import { useFormState } from 'react-dom'
 import { Controller, useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useRef } from 'react'
-import { useFormSubmit } from '@/libs/forms/hooks/form-submit-hook'
+import { useFormSubmitV2 } from '@/libs/forms/hooks/form-submit-hook'
 import { Field, Fieldset, Legend } from '@headlessui/react'
 import { Label } from '@/components/admin/forms/Label'
 import { ErrorMessage } from '@/components/admin/forms/ErrorMessage'
@@ -60,8 +59,8 @@ export function AdminStatementForm(props: {
 
   const {
     control,
-    handleSubmit,
-    formState: { errors },
+    trigger,
+    formState: { errors, isValid },
     register,
   } = useForm<FieldValues>({
     resolver: zodResolver(statementSchema),
@@ -74,16 +73,10 @@ export function AdminStatementForm(props: {
     },
   })
 
-  const formRef = useRef<HTMLFormElement>(null)
-
-  const { handleSubmitForm } = useFormSubmit<FieldValues>(
-    handleSubmit,
-    formAction,
-    formRef
-  )
+  const { handleSubmitForm } = useFormSubmitV2(isValid, trigger)
 
   return (
-    <form ref={formRef} onSubmit={handleSubmitForm}>
+    <form action={formAction} onSubmit={handleSubmitForm}>
       <input type="hidden" {...register('sourceId')} />
 
       <div className="container">

--- a/components/admin/tags/AdminTagForm.tsx
+++ b/components/admin/tags/AdminTagForm.tsx
@@ -3,7 +3,6 @@
 import { schema } from '@/libs/tags/schema'
 import { Field, Select } from '@headlessui/react'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useRef } from 'react'
 import { useFormState } from 'react-dom'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
@@ -16,7 +15,7 @@ import { AdminFormHeader } from '../layout/AdminFormHeader'
 import { AdminPageTitle } from '../layout/AdminPageTitle'
 import { AdminFormContent } from '../layout/AdminFormContent'
 import { AdminFormActions } from '../layout/AdminFormActions'
-import { useFormSubmit } from '@/libs/forms/hooks/form-submit-hook'
+import { useFormSubmitV2 } from '@/libs/forms/hooks/form-submit-hook'
 import { FormAction } from '@/libs/forms/form-action'
 import { ErrorMessage } from '@/components/admin/forms/ErrorMessage'
 import { useFormToasts } from '@/components/admin/forms/hooks/use-form-toasts'
@@ -41,8 +40,8 @@ export function AdminTagForm(props: {
 
   const {
     register,
-    handleSubmit,
-    formState: { errors },
+    trigger,
+    formState: { isValid, errors },
   } = useForm<z.output<typeof schema>>({
     resolver: zodResolver(schema),
     defaultValues: {
@@ -52,16 +51,10 @@ export function AdminTagForm(props: {
     },
   })
 
-  const formRef = useRef<HTMLFormElement>(null)
-
-  const { handleSubmitForm } = useFormSubmit<z.output<typeof schema>>(
-    handleSubmit,
-    formAction,
-    formRef
-  )
+  const { handleSubmitForm } = useFormSubmitV2(isValid, trigger)
 
   return (
-    <form ref={formRef} onSubmit={handleSubmitForm}>
+    <form action={formAction} onSubmit={handleSubmitForm}>
       <div className="container">
         <AdminFormHeader>
           <AdminPageTitle title={props.title} />

--- a/components/admin/tags/AdminTagForm.tsx
+++ b/components/admin/tags/AdminTagForm.tsx
@@ -15,7 +15,7 @@ import { AdminFormHeader } from '../layout/AdminFormHeader'
 import { AdminPageTitle } from '../layout/AdminPageTitle'
 import { AdminFormContent } from '../layout/AdminFormContent'
 import { AdminFormActions } from '../layout/AdminFormActions'
-import { useFormSubmitV2 } from '@/libs/forms/hooks/form-submit-hook'
+import { useFormSubmit } from '@/libs/forms/hooks/form-submit-hook'
 import { FormAction } from '@/libs/forms/form-action'
 import { ErrorMessage } from '@/components/admin/forms/ErrorMessage'
 import { useFormToasts } from '@/components/admin/forms/hooks/use-form-toasts'
@@ -51,7 +51,7 @@ export function AdminTagForm(props: {
     },
   })
 
-  const { handleSubmitForm } = useFormSubmitV2(isValid, trigger)
+  const { handleSubmitForm } = useFormSubmit(isValid, trigger)
 
   return (
     <form action={formAction} onSubmit={handleSubmitForm}>

--- a/libs/forms/hooks/form-submit-hook.ts
+++ b/libs/forms/hooks/form-submit-hook.ts
@@ -1,44 +1,6 @@
 'use client'
 
-import React, { RefObject, useCallback, useMemo } from 'react'
-import { invariant } from '@apollo/client/utilities/globals'
-
-/**
- * Creates form handler that is used in all the forms
- *
- * TODO: Improve types of handle submit and form action
- *
- * @deprecated useFormSubmitV2 instead
- * @param handleSubmit function given by the React hook forms
- * @param formAction Next.js action
- * @param form HTML Form element
- */
-export function useFormSubmit<TFieldValues extends Record<string, any>>(
-  handleSubmit: Function,
-  formAction: (formData: FormData) => void,
-  form: RefObject<HTMLFormElement | null>
-): {
-  handleSubmitForm: (e?: React.BaseSyntheticEvent) => Promise<void>
-} {
-  const handleSubmitForm = useMemo(() => {
-    return handleSubmit(
-      (data: TFieldValues) => {
-        invariant(form.current, 'Form HTML DOM element must be present.')
-
-        formAction(new FormData(form.current))
-
-        // TODO: @vaclavbohac Remove once we are sure the forms are bug free
-        console.debug('Valid form data', data)
-      },
-      (data: TFieldValues) => {
-        // TODO: @vaclavbohac Remove once we are sure the forms are bug free
-        console.debug('Invalid form data', data)
-      }
-    )
-  }, [form, formAction, handleSubmit])
-
-  return { handleSubmitForm }
-}
+import React, { useCallback } from 'react'
 
 export function useFormSubmitV2(
   isValid: boolean,

--- a/libs/forms/hooks/form-submit-hook.ts
+++ b/libs/forms/hooks/form-submit-hook.ts
@@ -2,7 +2,7 @@
 
 import React, { useCallback } from 'react'
 
-export function useFormSubmitV2(
+export function useFormSubmit(
   isValid: boolean,
   trigger: () => Promise<boolean>
 ) {


### PR DESCRIPTION
https://github.com/user-attachments/assets/6704eae7-4f02-4217-849f-5817ed403920

The new way of submitting has two advantages:
* it works with progressive enhancement - so it would work even with javascript turned off
* it supports the useFormState() hook meaning we can check if the form is currently being submitted (experimental in React 18 and new feature in React 19)

