### PR TITLE
Use display-1 for h1 and capital elements

### DIFF
--- a/app/(main)/articles/[slug]/page.tsx
+++ b/app/(main)/articles/[slug]/page.tsx
@@ -149,7 +149,7 @@ export default async function Article(props: { params: { slug: string } }) {
       <div className="row">
         <div className="col-sm-10 mx-sm-auto">
           <div>
-            <h1 className="display-4 fw-bold px-3 px-sm-0">{article.title}</h1>
+            <h1 className="display-1 fw-bold px-3 px-sm-0">{article.title}</h1>
             <ArticleIllustration article={article} />
             <div className="mt-4 mt-md-9 text-md-justify">
               <span className="perex">{article.perex}</span>

--- a/app/(main)/promises/[slug]/page.tsx
+++ b/app/(main)/promises/[slug]/page.tsx
@@ -118,7 +118,7 @@ export default async function Promises(
               <span className="d-flex align-items-center me-2">
                 <TitleIcon />
               </span>
-              <h1 className="display-4 fw-bold m-0 p-0">{article.title}</h1>
+              <h1 className="display-1 fw-bold m-0 p-0">{article.title}</h1>
             </div>
           </div>
           <div className="col col-12 col-lg-6">

--- a/app/(main)/search/page.tsx
+++ b/app/(main)/search/page.tsx
@@ -192,7 +192,7 @@ export default async function Search(props: PropsWithSearchParams) {
           !data.searchSpeakers.totalCount &&
           !data.searchStatements.totalCount && (
             <div className="col col-12 min-h-25vh py-10 text-center">
-              <h1 className="display-4 fw-bold">
+              <h1 className="display-1 fw-bold">
                 Nenašli jsme nic, co by odpovídalo Vašemu hledanému výrazu.
               </h1>
             </div>

--- a/app/(main)/speakers/[slug]/page.tsx
+++ b/app/(main)/speakers/[slug]/page.tsx
@@ -193,7 +193,7 @@ export default async function Speaker(
                 <span className="w-40px h-40px d-flex align-items-center justify-content-center bg-primary rounded-circle me-2">
                   <TrueIcon width={17} height={13} />
                 </span>
-                <span className="display-4 fs-bold">{speaker.stats?.true}</span>
+                <span className="display-1 fs-bold">{speaker.stats?.true}</span>
               </SpeakerLink>
 
               <SpeakerLink
@@ -214,7 +214,7 @@ export default async function Speaker(
                 <span className="w-40px h-40px d-flex align-items-center justify-content-center bg-gray rounded-circle me-2">
                   <UnverifiableIcon width={12} height={22} />
                 </span>
-                <span className="display-4 fs-bold">
+                <span className="display-1 fs-bold">
                   {speaker.stats?.unverifiable}
                 </span>
               </SpeakerLink>
@@ -238,7 +238,7 @@ export default async function Speaker(
                 <span className="w-40px h-40px d-flex align-items-center justify-content-center bg-red rounded-circle me-2">
                   <UntrueIcon width={13} height={13} />
                 </span>
-                <span className="display-4 fs-bold">
+                <span className="display-1 fs-bold">
                   {speaker.stats?.untrue}
                 </span>
               </SpeakerLink>
@@ -260,7 +260,7 @@ export default async function Speaker(
                 <span className="w-40px h-40px d-flex align-items-center justify-content-center bg-secondary rounded-circle me-2">
                   <MisleadingIcon width={4} height={22} />
                 </span>
-                <span className="display-4 fs-bold">
+                <span className="display-1 fs-bold">
                   {speaker.stats?.misleading}
                 </span>
               </SpeakerLink>

--- a/app/(main)/speakers/page.tsx
+++ b/app/(main)/speakers/page.tsx
@@ -129,7 +129,7 @@ export default async function Speakers(props: PropsWithSearchParams) {
             <div className="h-35px me-2">
               <PackmanIcon className="h-35px" />
             </div>
-            <h1 className="display-4 fw-bold m-0 p-0">
+            <h1 className="display-1 fw-bold m-0 p-0">
               Přehled politiků a političek
             </h1>
           </div>

--- a/app/(main)/statements/page.tsx
+++ b/app/(main)/statements/page.tsx
@@ -169,7 +169,7 @@ export default async function Statements(props: PropsWithSearchParams) {
             <div className="me-2">
               <TitleIcon className="h-35px" />
             </div>
-            <h1 className="display-4 fw-bold m-0 p-0">
+            <h1 className="display-1 fw-bold m-0 p-0">
               Přehled ověřených výroků
             </h1>
           </div>

--- a/app/(main)/workshops/page.tsx
+++ b/app/(main)/workshops/page.tsx
@@ -25,7 +25,7 @@ export default async function Workshops() {
   return (
     <div className="container">
       <div className="row g-5 mb-5">
-        <h1 className="display-4 fw-600">Workshopy</h1>
+        <h1 className="display-1 fw-bold">Workshopy</h1>
 
         <h2 className="fs-2 fw-bold">Nabízíme workshopy</h2>
       </div>

--- a/assets/styles/custom_variables.scss
+++ b/assets/styles/custom_variables.scss
@@ -1,18 +1,17 @@
 // This file is maintained by demagog team to keep consistency between
 // versions of bootstrap.
 
-
 // Colors
 $dark: #111827 !default;
 $dark-light: #172032 !default;
-$red: #E32219 !default;
+$red: #e32219 !default;
 
-$primary: #25AD23 !default;
-$primary-light: #77CC76 !default;
-$secondary: #FFBF00 !default;
+$primary: #25ad23 !default;
+$primary-light: #77cc76 !default;
+$secondary: #ffbf00 !default;
 
 $accordion-button-active-bg: $dark !default;
-$accordion-button-active-color: #FFF;
+$accordion-button-active-color: #fff;
 
 $accordion-button-focus-box-shadow: none;
 $accordion-button-focus-border-color: $dark-light;
@@ -45,10 +44,24 @@ $font-sizes: (
   4: $h4-font-size,
   5: $h5-font-size,
   6: $h6-font-size,
-  7: ($h6-font-size * 0.8),
+  7: (
+    $h6-font-size * 0.8,
+  ),
 );
 
-$small-font-size: $font-size-base *.95 !default;
+$small-font-size: $font-size-base * 0.95 !default;
+
+$display-font-sizes: (
+  // Size used for h1 elements
+  1: 3.5rem,
+
+  // FIXME: Make the rest of the display font sizes make sense for our design
+  2: 4.5rem,
+  3: 4rem,
+  4: 3.5rem,
+  5: 3rem,
+  6: 2.5rem
+) !default;
 
 // Border radius
 $border-radius: 1rem;
@@ -58,26 +71,66 @@ $spacer: 1rem !default;
 
 $spacers: (
   0: 0,
-  1: ($spacer * .25),
-  2: ($spacer * .5),
-	3: ($spacer * .75),
-	4: ($spacer * 1),
-	5: ($spacer * 1.25),
-	6: ($spacer * 1.5),
-	7: ($spacer * 1.75),
-	8: ($spacer * 2),
-	9: ($spacer * 2.25),
-	10: ($spacer * 2.5),
-	11: ($spacer * 2.75),
-	12: ($spacer * 3),
-	13: ($spacer * 3.25),
-	14: ($spacer * 3.5),
-	15: ($spacer * 3.75),
-	16: ($spacer * 4),
-	17: ($spacer * 4.25),
-	18: ($spacer * 4.5),
-	19: ($spacer * 4.75),
-	20: ($spacer * 5),
+  1: (
+    $spacer * 0.25,
+  ),
+  2: (
+    $spacer * 0.5,
+  ),
+  3: (
+    $spacer * 0.75,
+  ),
+  4: (
+    $spacer * 1,
+  ),
+  5: (
+    $spacer * 1.25,
+  ),
+  6: (
+    $spacer * 1.5,
+  ),
+  7: (
+    $spacer * 1.75,
+  ),
+  8: (
+    $spacer * 2,
+  ),
+  9: (
+    $spacer * 2.25,
+  ),
+  10: (
+    $spacer * 2.5,
+  ),
+  11: (
+    $spacer * 2.75,
+  ),
+  12: (
+    $spacer * 3,
+  ),
+  13: (
+    $spacer * 3.25,
+  ),
+  14: (
+    $spacer * 3.5,
+  ),
+  15: (
+    $spacer * 3.75,
+  ),
+  16: (
+    $spacer * 4,
+  ),
+  17: (
+    $spacer * 4.25,
+  ),
+  18: (
+    $spacer * 4.5,
+  ),
+  19: (
+    $spacer * 4.75,
+  ),
+  20: (
+    $spacer * 5,
+  ),
 );
 
 // Container
@@ -88,7 +141,7 @@ $grid-breakpoints: (
   md: 768px,
   lg: 992px,
   xl: 1200px,
-  xxl: 1400px
+  xxl: 1400px,
 ) !default;
 
 $container-max-widths: (
@@ -96,7 +149,7 @@ $container-max-widths: (
   md: 100%,
   lg: 100%,
   xl: 1180px,
-  xxl: 1380px
+  xxl: 1380px,
 ) !default;
 
 $symbol-sizes: (
@@ -113,12 +166,12 @@ $symbol-sizes: (
   65px: 65px,
   70px: 70px,
   75px: 75px,
-  100px:100px,
-  125px:125px,
-  150px:150px,
-  160px:160px,
-  175px:175px,
-    200px:200px
+  100px: 100px,
+  125px: 125px,
+  150px: 150px,
+  160px: 160px,
+  175px: 175px,
+  200px: 200px,
 ) !default;
 
 $custom-widths: (
@@ -196,7 +249,7 @@ $custom-sizes: (
   850px: 850px,
   900px: 900px,
   950px: 950px,
-  1000px: 1000px
+  1000px: 1000px,
 ) !default;
 
 $icon-sizes: (
@@ -207,51 +260,50 @@ $icon-sizes: (
   50: 50px,
 ) !default;
 
-
 $utilities: (
-  "width": (
+  'width': (
     responsive: true,
     property: width,
     class: w,
-    values: $custom-sizes
+    values: $custom-sizes,
   ),
-  "max-width": (
-      responsive: true,
-      property: max-width,
-      class: mw,
-      values: map-merge($custom-sizes, $custom-widths)
+  'max-width': (
+    responsive: true,
+    property: max-width,
+    class: mw,
+    values: map-merge($custom-sizes, $custom-widths),
   ),
-  "min-width": (
-      responsive: true,
-      property: min-width,
-      class: min-w,
-      values: map-merge($custom-sizes, $custom-widths)
+  'min-width': (
+    responsive: true,
+    property: min-width,
+    class: min-w,
+    values: map-merge($custom-sizes, $custom-widths),
   ),
-  "height": (
-      responsive: true,
-      property: height,
-      class: h,
-      values: map-merge($custom-sizes, $custom-heights)
+  'height': (
+    responsive: true,
+    property: height,
+    class: h,
+    values: map-merge($custom-sizes, $custom-heights),
   ),
-  "max-height": (
-      responsive: true,
-      property: max-height,
-      class: mh,
-      values: map-merge($custom-sizes, $custom-heights)
+  'max-height': (
+    responsive: true,
+    property: max-height,
+    class: mh,
+    values: map-merge($custom-sizes, $custom-heights),
   ),
-  "min-height": (
-      responsive: true,
-      property: min-height,
-      class: min-h,
-      values: map-merge($custom-sizes, $custom-heights)
+  'min-height': (
+    responsive: true,
+    property: min-height,
+    class: min-h,
+    values: map-merge($custom-sizes, $custom-heights),
   ),
-  "font-size": (
+  'font-size': (
     rfs: true,
     property: font-size,
     class: fs,
-    values: $font-sizes
+    values: $font-sizes,
   ),
-  "font-weight": (
+  'font-weight': (
     property: font-weight,
     class: fw,
     values: (
@@ -264,6 +316,6 @@ $utilities: (
       700: 700,
       800: 800,
       900: 900,
-    )
+    ),
   ),
-)
+);

--- a/components/about-us/AboutUsMenu.tsx
+++ b/components/about-us/AboutUsMenu.tsx
@@ -51,7 +51,7 @@ export function AboutUsMenu(props: {
 
   return (
     <nav className="side-nav w-100" data-target="components--sticky.sticky">
-      <h1 className="display-4 fw-bold mb-5 p-0">O nás</h1>
+      <h1 className="display-1 fw-bold mb-5 p-0">O nás</h1>
       <ul className="list">
         {data.accordionSections.edges?.map((edge, index) => {
           if (!edge?.node) {


### PR DESCRIPTION
Display 1 before:
![Screenshot 2024-12-10 115517](https://github.com/user-attachments/assets/e7e87044-9960-4943-8e17-2c0374e17a16)

Display 1 after:
![Screenshot 2024-12-10 115919](https://github.com/user-attachments/assets/dfdf4278-a833-44f5-89d3-ffb69468870b)

Replaced display-4 classes by the adjusted display-1.

