### PR TITLE
Tweak fs-7 and refactor all 14px font-sizes to re-use it

### DIFF
--- a/assets/styles/_layout.scss
+++ b/assets/styles/_layout.scss
@@ -25,9 +25,9 @@
       margin: 0 0 1rem;
 
       > figcaption {
-        font-size: 14px;
+        font-size: $h7-font-size;
         color: #9a95ab;
-        margin: .3rem 0 0 0;
+        margin: 0.3rem 0 0 0;
       }
     }
 
@@ -71,7 +71,7 @@
           margin-left: 8px;
           margin-right: 12px;
           color: white;
-          font-size: 14px;
+          font-size: $h7-font-size;
           line-height: 1.25;
         }
       }
@@ -84,7 +84,8 @@
     }
   }
 
-  #twitter, #facebook {
+  #twitter,
+  #facebook {
     display: none;
   }
 
@@ -106,9 +107,9 @@
       margin: 0 0 1rem;
 
       > figcaption {
-        font-size: 14px;
+        font-size: $h7-font-size;
         color: #9a95ab;
-        margin: .3rem 0 0 0;
+        margin: 0.3rem 0 0 0;
       }
     }
 
@@ -154,7 +155,7 @@
           margin-left: 8px;
           margin-right: 12px;
           color: white;
-          font-size: 14px;
+          font-size: $h7-font-size;
           line-height: 1.25;
         }
       }
@@ -202,7 +203,8 @@
     margin-top: 3rem;
   }
 
-  #twitter, #facebook {
+  #twitter,
+  #facebook {
     flex: 1 0 50%;
     max-width: 50%; // for IE11 not respecting border-box with flex-basis
     box-sizing: border-box;

--- a/assets/styles/article/_redesign.scss
+++ b/assets/styles/article/_redesign.scss
@@ -125,10 +125,6 @@
       text-underline-offset: 2px;
     }
 
-    .fs-12px {
-      font-size: 12px;
-    }
-
     .fs-16px {
       font-size: 16px;
     }
@@ -139,8 +135,7 @@
 
     .content-text-node {
       p {
-        @extend .mt-6;
-        font-size: 14px;
+        @extend .mt-6, .fs-7;
       }
 
       h2 {
@@ -183,8 +178,7 @@
           @extend .mb-0;
 
           li {
-            @extend .li-item;
-            font-size: 14px;
+            @extend .li-item, .fs-7;
           }
 
           li.li-item:not(:last-child) {
@@ -198,10 +192,6 @@
     }
 
     @media (min-width: 768px) {
-      .fs-md-14px {
-        font-size: 14px;
-      }
-
       .fs-md-26px {
         font-size: 26px;
       }
@@ -212,8 +202,10 @@
 
       .content-text-node {
         p {
-          font-size: 16px;
+          // FIXME: Remove this once we have fs- for 1rem
+          font-size: 1rem !important;
         }
+
         h2 {
           font-size: 32px;
         }
@@ -241,19 +233,11 @@
     text-underline-offset: 2px;
   }
 
-  .fs-12px {
-    font-size: 12px;
-  }
-
   .lh-110percent {
     line-height: 110% !important;
   }
 
   @media (min-width: 768px) {
-    .fs-14px {
-      font-size: 14px;
-    }
-
     .lh-md-base {
       line-height: 1.5;
     }

--- a/assets/styles/article/player.scss
+++ b/assets/styles/article/player.scss
@@ -183,10 +183,10 @@
   }
 
   .open-player-button-overlay-text {
+    @extend .fs-7;
     margin-left: 15px;
     margin-right: 20px;
     color: white;
-    font-size: 14px;
     line-height: 1.25;
     font-family: Lato, sans-serif;
     font-weight: normal;

--- a/assets/styles/campaign.scss
+++ b/assets/styles/campaign.scss
@@ -1,7 +1,7 @@
-@import "custom_variables";
-@import "vendor/mixins";
+@import 'custom_variables';
+@import 'vendor/mixins';
 
-$orange: #FFBF00;
+$orange: #ffbf00;
 
 /*
 
@@ -38,16 +38,18 @@ html {
   background-position: center;
   background-size: cover;
 
-  .blur-bg, .blur-bg p, .blur-bg h1 {
+  .blur-bg,
+  .blur-bg p,
+  .blur-bg h1 {
     position: relative;
     z-index: 1;
   }
 
   .blur-bg:before {
-    content: "";
+    content: '';
     position: absolute;
     border-radius: 22px;
-    background: rgba(0, 0, 0, 0.20);
+    background: rgba(0, 0, 0, 0.2);
     filter: blur(17.5px);
     backdrop-filter: blur(2px);
     top: 0;
@@ -83,7 +85,7 @@ html {
     width: 100%;
     top: 50%;
     left: 50%;
-    transform: translate(-50%, -50%)
+    transform: translate(-50%, -50%);
   }
 }
 
@@ -99,7 +101,9 @@ html {
 }
 
 .page3 {
-  background-image: url(image_path('campaign/obrazek-sundana-maska-small.webp'));
+  background-image: url(image_path(
+    'campaign/obrazek-sundana-maska-small.webp'
+  ));
   background-repeat: no-repeat;
   background-position: center;
   background-size: cover;
@@ -146,7 +150,7 @@ html {
 }
 
 .headerOrange {
-  color: #FFBF00;
+  color: #ffbf00;
   font-size: 32px;
   font-style: normal;
   font-weight: 800;
@@ -156,7 +160,7 @@ html {
 }
 
 .headerWhite {
-  color: #FFF;
+  color: #fff;
   font-size: 32px;
   font-style: normal;
   font-weight: 600;
@@ -180,7 +184,7 @@ html {
 }
 
 .headerPage3 {
-  color: #FFF;
+  color: #fff;
   font-size: 32px;
   font-style: normal;
   font-weight: 600;
@@ -190,7 +194,7 @@ html {
 }
 
 .headerOrangePage3 {
-  color: #FFBF00;
+  color: #ffbf00;
   font-weight: 900;
 }
 
@@ -200,7 +204,7 @@ html {
 }
 
 .textWhite {
-  color: #FFF;
+  color: #fff;
   font-size: 15px;
   font-style: normal;
   font-weight: 600;
@@ -212,7 +216,7 @@ html {
 }
 
 .textPage3 {
-  color: #FFF;
+  color: #fff;
   font-size: 15px;
   font-style: normal;
   font-weight: 600;
@@ -220,13 +224,13 @@ html {
 }
 
 .linkOrange {
-  color: #FFBF00;
+  color: #ffbf00;
   text-decoration: underline;
 }
 
 .listPage3 {
   display: list-item;
-  color: #FFF;
+  color: #fff;
   font-size: 15px;
   font-style: normal;
   font-weight: 600;
@@ -260,16 +264,16 @@ html {
 }
 
 .buttonsPage3 {
-  color: #FFF;
+  @extend .fs-7;
+  color: #fff;
   text-align: center;
-  font-size: 14px;
   font-style: normal;
   font-weight: 600;
   line-height: 38px;
   height: 38px;
   width: 100%;
   border-radius: 32.5px;
-  background: rgba(0, 0, 0, 0.20);
+  background: rgba(0, 0, 0, 0.2);
   backdrop-filter: blur(2px);
   border-color: white;
   border-style: solid;
@@ -278,7 +282,6 @@ html {
   justify-content: center;
   text-decoration: none;
 }
-
 
 .videoContainerPage3 {
   display: flex;
@@ -302,8 +305,8 @@ html {
 }
 
 .playVideoText {
-  color: #FFF;
-  font-size: 14px;
+  @extend .fs-7;
+  color: #fff;
   font-style: normal;
   font-weight: 600;
   line-height: 40px;
@@ -316,7 +319,7 @@ html {
 }
 
 .partnersP {
-  color: #E5E7EB;
+  color: #e5e7eb;
   font-size: 12px;
   font-style: italic;
   font-weight: 500;
@@ -348,7 +351,6 @@ html {
     margin: 20px;
   }
 }
-
 
 .footer > div {
   display: flex;
@@ -430,7 +432,9 @@ html {
   }
 
   .page3 {
-    background-image: url(image_path('campaign/obrazek-sundana-maska-big.webp'));
+    background-image: url(image_path(
+      'campaign/obrazek-sundana-maska-big.webp'
+    ));
   }
 
   .logoDemagog {
@@ -527,10 +531,10 @@ html {
   }
 
   .buttonsPage3:hover {
-    background-color: #FFBF00;
+    background-color: #ffbf00;
     color: black;
-    border-color: #FFBF00;
-    transition: all .4s ease;
+    border-color: #ffbf00;
+    transition: all 0.4s ease;
   }
 
   .btnTop {
@@ -566,7 +570,7 @@ html {
   }
 
   .playVideoText:hover {
-    color: #FFBF00;
+    color: #ffbf00;
   }
 
   .arrowsContainer2 {
@@ -584,7 +588,7 @@ html {
     width: 100%;
     top: 50%;
     left: 50%;
-    transform: translate(-50%, -50%)
+    transform: translate(-50%, -50%);
   }
 
   .arrowFwdBtn {
@@ -635,10 +639,10 @@ html {
   }
 
   .blurBg:before {
-    content: "";
+    content: '';
     position: absolute;
     border-radius: 22px;
-    background: rgba(0, 0, 0, 0.20);
+    background: rgba(0, 0, 0, 0.2);
     filter: blur(17.5px);
     backdrop-filter: blur(2px);
     top: 0;
@@ -663,17 +667,17 @@ html {
     padding: 50px 50px 40px;
   }
 
-  .page1, .page2 {
+  .page1,
+  .page2 {
     .footer {
       margin-top: 0;
     }
   }
 
-  .page3 .footer  {
+  .page3 .footer {
     padding-top: 0;
   }
 }
-
 
 @media screen and (min-height: 1029px) {
   .page {
@@ -692,12 +696,11 @@ html {
     margin: 0 auto;
   }
 
-  .page3 .footer  {
+  .page3 .footer {
     padding-top: 0;
     margin-top: -90px;
   }
 }
-
 
 @include media-breakpoint-up(xs) {
   .container {

--- a/assets/styles/campaign/styles.module.css
+++ b/assets/styles/campaign/styles.module.css
@@ -44,7 +44,9 @@ ul {
 }
 
 .page1 {
-  background: url('../../images/campaign/obrazek-telka-small.png'), lightgray 50% / cover no-repeat;
+  background:
+    url('../../images/campaign/obrazek-telka-small.png'),
+    lightgray 50% / cover no-repeat;
   background-repeat: no-repeat;
   background-position: center;
   background-size: cover;
@@ -65,7 +67,7 @@ ul {
 }
 
 .headerOrange {
-  color: #FFBF00;
+  color: #ffbf00;
   font-size: 32px;
   font-style: normal;
   font-weight: 800;
@@ -75,7 +77,7 @@ ul {
 }
 
 .headerWhite {
-  color: #FFF;
+  color: #fff;
   font-size: 32px;
   font-style: normal;
   font-weight: 600;
@@ -99,7 +101,7 @@ ul {
 }
 
 .headerWhitePage2 {
-  color: #FFF;
+  color: #fff;
   font-size: 32px;
   font-style: normal;
   font-weight: 600;
@@ -111,7 +113,7 @@ ul {
 }
 
 .headerPage3 {
-  color: #FFF;
+  color: #fff;
   font-size: 32px;
   font-style: normal;
   font-weight: 600;
@@ -124,7 +126,7 @@ ul {
 }
 
 .headerOrangePage3 {
-  color: #FFBF00;
+  color: #ffbf00;
   font-weight: 900;
 }
 
@@ -153,10 +155,10 @@ ul {
   right: 0;
   left: 20px;
   bottom: 20px;
-  content: "";
+  content: '';
   position: absolute;
   border-radius: 22px;
-  background: rgba(0, 0, 0, 0.20);
+  background: rgba(0, 0, 0, 0.2);
   filter: blur(17.5px);
   backdrop-filter: blur(2px);
 }
@@ -172,7 +174,7 @@ ul {
 }
 
 .textWhite {
-  color: #FFF;
+  color: #fff;
   font-size: 15px;
   font-style: normal;
   font-weight: 600;
@@ -184,7 +186,7 @@ ul {
 }
 
 .textOrange {
-  color: #FFBF00;
+  color: #ffbf00;
   font-size: 15px;
   font-style: normal;
   font-weight: 800;
@@ -192,14 +194,13 @@ ul {
 }
 
 .additionalInfo {
-  color: #FFF;
+  color: #fff;
   font-size: 12px;
   font-style: italic;
   font-weight: 400;
   line-height: 16px;
   margin-bottom: 30px;
   padding-right: 23px;
-
 }
 
 /*nachystany blur pozadi page3 mobile. Kdyby se pouzil, je treba jeste upravit rozmery*/
@@ -228,7 +229,7 @@ ul {
 }*/
 
 .textPage3 {
-  color: #FFF;
+  color: #fff;
   font-size: 15px;
   font-style: normal;
   font-weight: 600;
@@ -240,18 +241,18 @@ ul {
 }
 
 .textOrangePage3 {
-  color: #FFBF00;
+  color: #ffbf00;
   font-weight: 800;
 }
 
 .linkOrange {
-  color: #FFBF00;
+  color: #ffbf00;
   text-decoration: underline;
 }
 
 .listPage3 {
   display: list-item;
-  color: #FFF;
+  color: #fff;
   font-size: 15px;
   font-style: normal;
   font-weight: 600;
@@ -284,26 +285,6 @@ ul {
   width: 350px;
 }
 
-.buttonsPage3 {
-  color: #FFF;
-  text-align: center;
-  font-size: 14px;
-  font-style: normal;
-  font-weight: 600;
-  line-height: 38px;
-  height: 38px;
-  width: 100%;
-  border-radius: 32.5px;
-  background: rgba(0, 0, 0, 0.20);
-  backdrop-filter: blur(2px);
-  border-color: white;
-  border-style: solid;
-  border-width: 1px;
-  display: flex;
-  justify-content: center;
-  text-decoration: none;
-}
-
 .btnTop {
   margin-bottom: 16px;
 }
@@ -328,22 +309,8 @@ ul {
   margin-right: 8px;
 }
 
-.playVideoText {
-  color: #FFF;
-  font-size: 14px;
-  font-style: normal;
-  font-weight: 600;
-  line-height: 40px;
-  text-decoration-line: underline;
-  cursor: pointer;
-  margin: 0px;
-  margin-left: 8px;
-  background-color: inherit;
-  border-style: none;
-}
-
 .partnersP {
-  color: #E5E7EB;
+  color: #e5e7eb;
   font-size: 12px;
   font-style: italic;
   font-weight: 500;
@@ -378,7 +345,6 @@ ul {
   justify-content: center;
   align-items: center;
 }
-
 
 .logoCedmo {
   width: 90px;
@@ -586,10 +552,10 @@ ul {
   }
 
   .buttonsPage3:hover {
-    background-color: #FFBF00;
+    background-color: #ffbf00;
     color: black;
-    border-color: #FFBF00;
-    transition: all .4s ease;
+    border-color: #ffbf00;
+    transition: all 0.4s ease;
   }
 
   .btnTop {
@@ -625,7 +591,7 @@ ul {
   }
 
   .playVideoText:hover {
-    color: #FFBF00;
+    color: #ffbf00;
   }
 
   .arrowsContainer2 {
@@ -643,7 +609,7 @@ ul {
     width: 100%;
     top: 50%;
     left: 50%;
-    transform: translate(-50%, -50%)
+    transform: translate(-50%, -50%);
   }
 
   .arrowFwdBtn {
@@ -704,10 +670,10 @@ ul {
   }
 
   .blurBg:before {
-    content: "";
+    content: '';
     position: absolute;
     border-radius: 22px;
-    background: rgba(0, 0, 0, 0.20);
+    background: rgba(0, 0, 0, 0.2);
     filter: blur(17.5px);
     backdrop-filter: blur(2px);
     top: 0;
@@ -723,7 +689,6 @@ ul {
     bottom: 28px;
   }
 }
-
 
 @media screen and (min-width: 1390px) {
   .partnersContainer1Page3 {

--- a/assets/styles/custom_variables.scss
+++ b/assets/styles/custom_variables.scss
@@ -36,6 +36,7 @@ $h3-font-size: $font-size-base * 1.35 !default;
 $h4-font-size: $font-size-base * 1.25 !default;
 $h5-font-size: $font-size-base * 1.15 !default;
 $h6-font-size: $font-size-base * 1.075 !default;
+$h7-font-size: $font-size-base * 0.875 !default;
 
 $font-sizes: (
   1: $h1-font-size,
@@ -44,9 +45,7 @@ $font-sizes: (
   4: $h4-font-size,
   5: $h5-font-size,
   6: $h6-font-size,
-  7: (
-    $h6-font-size * 0.8,
-  ),
+  7: $h7-font-size,
 );
 
 $small-font-size: $font-size-base * 0.95 !default;

--- a/assets/styles/homepage/_cover_story.scss
+++ b/assets/styles/homepage/_cover_story.scss
@@ -31,10 +31,10 @@
       }
 
       .factcheck-video-label-text {
+        @extend .fs-7;
         margin-left: 8px;
         margin-right: 12px;
         color: white;
-        font-size: 14px;
         line-height: 1.25;
       }
     }

--- a/assets/styles/homepage/_homepage_donate_and_subscribe.scss
+++ b/assets/styles/homepage/_homepage_donate_and_subscribe.scss
@@ -31,15 +31,17 @@
       padding: 0.4rem 0.9rem;
       cursor: pointer;
 
-      &:hover, &:active {
+      &:hover,
+      &:active {
         background-color: var(--orange);
         color: #ffffff;
       }
     }
 
     .accept-terms {
+      @extend .fs-7;
+
       margin-top: 15px;
-      font-size: 14px;
       line-height: 1.4;
     }
   }

--- a/assets/styles/homepage/index.scss
+++ b/assets/styles/homepage/index.scss
@@ -3,7 +3,6 @@
   flex-direction: row;
   flex-wrap: wrap;
 
-  
   > .intro {
     margin: 50px 0 0 0;
     display: flex;
@@ -79,7 +78,8 @@
           }
         }
 
-        &:hover, &:active {
+        &:hover,
+        &:active {
           > .button-label {
             background: rgba(0, 0, 0, 0.7);
           }
@@ -100,7 +100,9 @@
 
   .intro-video-modal {
     display: none;
-    &.is-open { display: block; }
+    &.is-open {
+      display: block;
+    }
 
     .intro-video-modal-overlay {
       position: fixed;
@@ -108,7 +110,7 @@
       left: 0;
       right: 0;
       bottom: 0;
-      background: rgba(0,0,0,0.7);
+      background: rgba(0, 0, 0, 0.7);
       padding: 15px;
       display: flex;
       justify-content: center;
@@ -142,7 +144,8 @@
       color: #ffffff;
       outline: none;
 
-      &:hover, &:active {
+      &:hover,
+      &:active {
         color: #f26538;
       }
     }
@@ -153,7 +156,9 @@
       height: 0;
       overflow: hidden;
 
-      > iframe, > object, > embed {
+      > iframe,
+      > object,
+      > embed {
         position: absolute;
         top: 0;
         left: 0;
@@ -181,7 +186,7 @@
     > .sidebar {
       flex: 0 0 250px;
       padding: 25px 25px 20px 25px;
-      background: #E1EBF3;
+      background: #e1ebf3;
 
       > .donate-section {
         > h2 {
@@ -228,15 +233,17 @@
       padding: 0.4rem 0.9rem;
       cursor: pointer;
 
-      &:hover, &:active {
+      &:hover,
+      &:active {
         background-color: var(--orange);
         color: #ffffff;
       }
     }
 
     .accept-terms {
+      @extend .fs-7;
+
       margin-top: 15px;
-      font-size: 14px;
       line-height: 1.4;
     }
   }

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -3,6 +3,8 @@
 @import 'custom_variables';
 @import 'vendor/bootstrap';
 
+@import 'responsive/font-size';
+
 @import './core/base';
 @import './core/header';
 @import './core/btn';
@@ -43,7 +45,8 @@
   }
 
   .widget-periodic-button {
-    font-size: 14px;
+    @extend .fs-7;
+
     padding: 10px 5px 9px 5px;
     text-align: center;
     letter-spacing: 0.3px;
@@ -57,7 +60,7 @@
     display: flex;
     justify-content: space-between;
     margin-bottom: 8px;
-    font-size: 14px;
+    @extend .fs-7;
   }
 
   .widget-custom-title {
@@ -77,7 +80,7 @@
   }
 
   .widget-custom-input {
-    font-size: 14px;
+    @extend .fs-7;
     padding: 10px 5px 9px 5px;
     margin-bottom: 2px;
     cursor: auto;
@@ -104,8 +107,8 @@
   }
 
   .widget-entries-button {
+    @extend .fs-7;
     width: 100%;
-    font-size: 14px;
     padding: 10px 5px 9px 5px;
     cursor: pointer;
     text-align: center;
@@ -119,7 +122,7 @@
   }
 
   .donate-submit {
-    font-size: 14px;
+    @extend .fs-7;
     padding: 10px 5px 9px 5px;
     letter-spacing: 0.3px;
     line-height: 1.2;

--- a/assets/styles/promises/overview.scss
+++ b/assets/styles/promises/overview.scss
@@ -55,7 +55,7 @@
           flex: 3 0 240px;
           height: 26px;
           position: relative;
-          background-color: #D7E5EF;
+          background-color: #d7e5ef;
           border-radius: 3px;
 
           .stats-line-bar-inner {
@@ -66,7 +66,8 @@
           &.fulfilled .stats-line-bar-inner {
             background-color: var(--true);
           }
-          &.partially-fulfilled .stats-line-bar-inner, &.in-progress .stats-line-bar-inner {
+          &.partially-fulfilled .stats-line-bar-inner,
+          &.in-progress .stats-line-bar-inner {
             background-color: var(--unverifiable);
           }
           &.broken .stats-line-bar-inner {
@@ -116,7 +117,8 @@
       margin-right: 0;
     }
 
-    .area-filter, .evaluation-filter {
+    .area-filter,
+    .evaluation-filter {
       margin-bottom: 30px;
 
       .filter-options-list {
@@ -127,15 +129,16 @@
         .filter-option-button {
           margin: 0 6px 6px 0;
           display: block;
-          border: 1px solid #C5BCE0;
+          border: 1px solid #c5bce0;
           border-radius: 3px;
           color: var(--violet);
 
           &.active {
-            background-color: #FFE0D6;
+            background-color: #ffe0d6;
           }
 
-          &:hover, &:active {
+          &:hover,
+          &:active {
             text-decoration: none;
             border-color: var(--orange);
           }
@@ -183,7 +186,7 @@
       border-collapse: collapse;
 
       thead th {
-        border-bottom: 1px solid #D7E5FB;
+        border-bottom: 1px solid #d7e5fb;
         text-align: left;
         padding: 12px 15px;
         text-transform: uppercase;
@@ -196,7 +199,7 @@
       tbody tr.summary {
         td {
           padding: 12px 15px;
-          border-bottom: 1px solid #D7E5FB;
+          border-bottom: 1px solid #d7e5fb;
           cursor: pointer;
 
           &.name-cell {
@@ -263,7 +266,7 @@
         }
 
         &.expanded td {
-          border-bottom: 1px solid #D7E5FB;
+          border-bottom: 1px solid #d7e5fb;
 
           .hiding-container {
             display: block;
@@ -272,7 +275,7 @@
       }
 
       @media (max-width: 599.9px) {
-        border-top: 1px solid #D7E5FB;
+        border-top: 1px solid #d7e5fb;
         display: block;
         margin: 0 -15px;
         width: auto;
@@ -281,13 +284,15 @@
           display: none;
         }
 
-        tbody, tbody tr, tbody tr td {
+        tbody,
+        tbody tr,
+        tbody tr td {
           display: block;
         }
 
         tbody tr.summary {
           padding: 10px 15px 15px 15px;
-          border-bottom: 1px solid #D7E5FB;
+          border-bottom: 1px solid #d7e5fb;
 
           td {
             padding: 5px 0;
@@ -332,7 +337,8 @@
         }
       }
 
-      tbody tr.summary.hidden, tbody tr.detail.hidden {
+      tbody tr.summary.hidden,
+      tbody tr.detail.hidden {
         display: none;
       }
     }
@@ -346,7 +352,7 @@
       flex: 2 2 200px;
       margin: 0 0 20px 0;
 
-      border: 1px solid #CAD9E6;
+      border: 1px solid #cad9e6;
       border-radius: 5px;
       background-color: white;
       padding: 10px 15px 15px 15px;
@@ -405,7 +411,8 @@
         font-size: var(--normal-typesize);
         cursor: pointer;
 
-        &:hover, &:active {
+        &:hover,
+        &:active {
           text-decoration: underline;
         }
       }
@@ -434,13 +441,18 @@
           margin-top: 7px;
 
           background:
-            linear-gradient(var(--white) 30%, hsla(0,0%,100%, 0)),
-            linear-gradient(hsla(0,0%,100%,0) 10px, var(--white) 70%) bottom,
-            radial-gradient(at top, rgba(0,0,0,0.3), transparent 70%),
-            radial-gradient(at bottom, rgba(0,0,0,0.3), transparent 70%) bottom;
-          background-repeat:no-repeat;
-          background-size: 100% 30px, 100% 30px, 100% 15px, 100% 15px;
-          background-attachment:local, local, scroll, scroll;
+            linear-gradient(var(--white) 30%, hsla(0, 0%, 100%, 0)),
+            linear-gradient(hsla(0, 0%, 100%, 0) 10px, var(--white) 70%) bottom,
+            radial-gradient(at top, rgba(0, 0, 0, 0.3), transparent 70%),
+            radial-gradient(at bottom, rgba(0, 0, 0, 0.3), transparent 70%)
+              bottom;
+          background-repeat: no-repeat;
+          background-size:
+            100% 30px,
+            100% 30px,
+            100% 15px,
+            100% 15px;
+          background-attachment: local, local, scroll, scroll;
 
           * {
             line-height: 25px;
@@ -456,8 +468,12 @@
 
         &.with-full-explanation {
           .toggle-full-explanation {
-            .show { display: none; }
-            .hide { display: inline; }
+            .show {
+              display: none;
+            }
+            .hide {
+              display: inline;
+            }
           }
 
           .full-explanation {
@@ -479,7 +495,8 @@
         margin-left: 0;
 
         .explanation-container {
-          .full-explanation, &.full-explanation-only .full-explanation {
+          .full-explanation,
+          &.full-explanation-only .full-explanation {
             max-height: 300px;
           }
         }
@@ -509,7 +526,9 @@
 
   .embed-modal {
     display: none;
-    &.is-open { display: block; }
+    &.is-open {
+      display: block;
+    }
 
     .embed-modal-overlay {
       position: fixed;
@@ -517,7 +536,7 @@
       left: 0;
       right: 0;
       bottom: 0;
-      background: rgba(0,0,0,0.6);
+      background: rgba(0, 0, 0, 0.6);
       display: flex;
       justify-content: center;
       align-items: center;
@@ -549,7 +568,8 @@
         color: #3c325c;
         outline: none;
 
-        &:hover, &:active {
+        &:hover,
+        &:active {
           color: #f26538;
         }
       }
@@ -560,31 +580,34 @@
         margin-top: 20px;
 
         button {
-          border: 1px solid #C5BCE0;
+          @extend .fs-7;
+
+          border: 1px solid #c5bce0;
           border-radius: 3px;
           margin: 0;
           padding: 5px 10px;
-          font-size: 14px;
           cursor: pointer;
           outline: none;
           color: #3c325c;
           font-family: Lato, sans-serif;
 
           &.active {
-            background-color: #FFE0D6;
+            background-color: #ffe0d6;
           }
 
-          &:hover, &:active {
+          &:hover,
+          &:active {
             border-color: #f26538;
           }
         }
       }
 
       .embed-code {
+        @extend .fs-7;
+
         box-sizing: border-box;
         width: 100%;
         padding: 5px;
-        font-size: 14px;
       }
 
       .embed-preview-container {
@@ -592,5 +615,4 @@
       }
     }
   }
-
 }

--- a/assets/styles/responsive/font-size.scss
+++ b/assets/styles/responsive/font-size.scss
@@ -1,0 +1,16 @@
+// Responsive font-sizes
+
+// Needs to be defined before the responsive font-sizes
+.fs-12px {
+  font-size: 12px;
+}
+
+@each $breakpoint in map-keys($grid-breakpoints) {
+  @include media-breakpoint-up($breakpoint) {
+    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+
+    .fs#{$infix}-7 {
+      font-size: $h7-font-size;
+    }
+  }
+}

--- a/assets/styles/shared/_donate_and_subscribe.scss
+++ b/assets/styles/shared/_donate_and_subscribe.scss
@@ -32,15 +32,16 @@
       padding: 0.4rem 0.9rem;
       cursor: pointer;
 
-      &:hover, &:active {
+      &:hover,
+      &:active {
         background-color: var(--orange);
         color: #ffffff;
       }
     }
 
     .accept-terms {
+      @extend .fs-7;
       margin-top: 15px;
-      font-size: 14px;
       line-height: 1.4;
     }
   }

--- a/assets/styles/shared/_infobox.scss
+++ b/assets/styles/shared/_infobox.scss
@@ -1,6 +1,6 @@
 .container-shared-infobox {
   .infobox-button {
-    background-color: #E7EFF6;
+    background-color: #e7eff6;
     border: none;
     border-radius: 5px;
     margin: 0;
@@ -14,16 +14,17 @@
 
     .info-icon {
       flex: 0 0 24px;
-  
+
       img {
         display: block;
       }
     }
-  
+
     .info-text {
+      @extend .fs-7;
+
       flex: 1 0 0px;
       margin-left: 12px;
-      font-size: 14px;
       line-height: 1.5;
 
       &.info-text-veracities {
@@ -34,7 +35,8 @@
           margin: 2px 0;
         }
 
-        .veracity, .text-inner {
+        .veracity,
+        .text-inner {
           margin-right: 5px;
         }
       }
@@ -52,15 +54,18 @@
         }
       }
     }
-  
-    &:hover, &:focus {
-      background-color: #F3DBD3;
+
+    &:hover,
+    &:focus {
+      background-color: #f3dbd3;
     }
   }
 
   .infobox-modal {
     display: none;
-    &.is-open { display: block; }
+    &.is-open {
+      display: block;
+    }
 
     .infobox-modal-overlay {
       position: fixed;
@@ -68,7 +73,7 @@
       left: 0;
       right: 0;
       bottom: 0;
-      background: rgba(0,0,0,0.6);
+      background: rgba(0, 0, 0, 0.6);
       padding: 15px;
       display: flex;
       justify-content: center;
@@ -103,7 +108,8 @@
         color: #3c325c;
         outline: none;
 
-        &:hover, &:active {
+        &:hover,
+        &:active {
           color: #f26538;
         }
       }
@@ -122,7 +128,8 @@
       margin: 2px 0;
     }
 
-    .veracity, .text-inner {
+    .veracity,
+    .text-inner {
       margin-right: 5px;
     }
   }

--- a/assets/styles/statement/show.scss
+++ b/assets/styles/statement/show.scss
@@ -8,7 +8,7 @@
     flex-direction: row;
     align-items: center;
 
-    .portrait  {
+    .portrait {
       flex: 0 0 var(--large-portrait);
       width: var(--large-portrait);
       height: var(--large-portrait);
@@ -32,7 +32,8 @@
       text-align: left;
     }
 
-    &:hover, &:focus {
+    &:hover,
+    &:focus {
       text-decoration: none;
 
       .portrait {
@@ -63,7 +64,7 @@
 
       // CSS-only arrow pointing to the portrait
       &:after {
-        content: " ";
+        content: ' ';
 
         position: absolute;
         right: 100%;
@@ -95,19 +96,20 @@
     }
 
     cite {
+      @extend .fs-7;
+
       display: block;
-      color: #918AA8;
-      font-size: 14px;
+      color: #918aa8;
       line-height: 1.3;
       text-transform: uppercase;
       margin: 10px 0 0 24px;
       font-style: normal;
-  
+
       &::before {
         content: '— ';
         margin: 0 2.5px 0 2px;
       }
-  
+
       .date {
         white-space: nowrap;
       }
@@ -124,16 +126,17 @@
       display: flex;
       flex-direction: row;
       flex-wrap: wrap;
-  
+
       .tag-item {
+        @extend .fs-7;
+
         flex: 0 0 auto;
         margin-right: 10px;
-        color: #918AA8;
-        font-size: 14px;
+        color: #918aa8;
         line-height: 1.3;
         text-transform: uppercase;
         white-space: nowrap;
-  
+
         &::before {
           content: '';
           display: inline-block;
@@ -167,7 +170,7 @@
       display: flex;
       flex-direction: column;
     }
-  
+
     .infobox-item {
       flex: 0 0 auto;
       margin: 0 0 12px 0;

--- a/components/article/ArticleResponsivePerex.tsx
+++ b/components/article/ArticleResponsivePerex.tsx
@@ -27,19 +27,19 @@ export function ArticleResponsivePerex(props: {
     >
       <span
         className={classNames({
-          'fs-12px fs-md-14px lh-md-base d-xl-none': props.isEmbedded,
+          'fs-12px fs-md-7 lh-md-base d-xl-none': props.isEmbedded,
           'fs-6': !props.isEmbedded,
         })}
       >
         {perexSmall}
       </span>
       {props.isEmbedded && (
-        <span className="fs-12px fs-md-14px lh-md-base d-none d-xl-block d-xxl-none">
+        <span className="fs-12px fs-md-7 lh-md-base d-none d-xl-block d-xxl-none">
           {perexLarge}
         </span>
       )}
       {props.isEmbedded && (
-        <span className="fs-12px fs-md-14px lh-md-base d-none d-xxl-block">
+        <span className="fs-12px fs-md-7 lh-md-base d-none d-xxl-block">
           {perexXLarge}
         </span>
       )}

--- a/components/article/Item.tsx
+++ b/components/article/Item.tsx
@@ -101,7 +101,7 @@ export default function ArticleItem(props: {
           </h2>
           <div
             className={classNames('mb-2', {
-              'text-muted fs-12px fs-md-14px': isEmbedded,
+              'text-muted fs-12px fs-md-7': isEmbedded,
             })}
           >
             {article.articleType === 'default' && article.source && (
@@ -126,10 +126,10 @@ export default function ArticleItem(props: {
             )}
             {isEmbedded && article.source?.sourceUrl && (
               <>
-                <span className="col col-auto fs-12px fs-md-14px text-muted">
+                <span className="col col-auto fs-12px fs-md-7 text-muted">
                   ,{' '}
                 </span>
-                <span className="col col-auto fs-12px fs-md-14px text-decoration-underline underline-offset-2px">
+                <span className="col col-auto fs-12px fs-md-7 text-decoration-underline underline-offset-2px">
                   <i>
                     <a
                       href={article.source.sourceUrl}

--- a/components/article/SingleStatementArticlePreview.tsx
+++ b/components/article/SingleStatementArticlePreview.tsx
@@ -164,7 +164,7 @@ export function SingleStatementArticlePreview(props: {
           </h2>
           <div
             className={classNames('mb-2', {
-              'text-muted fs-12px fs-md-14px': isEmbedded,
+              'text-muted fs-12px fs-md-7': isEmbedded,
             })}
           >
             <i className={classNames({ 'text-muted': isEmbedded })}>
@@ -174,10 +174,10 @@ export function SingleStatementArticlePreview(props: {
             </i>
             {isEmbedded && article.statement?.source?.sourceUrl && (
               <>
-                <span className="col col-auto fs-12px fs-md-14px text-muted">
+                <span className="col col-auto fs-12px fs-md-7 text-muted">
                   ,{' '}
                 </span>
-                <span className="col col-auto fs-12px fs-md-14px text-decoration-underline underline-offset-2px">
+                <span className="col col-auto fs-12px fs-md-7 text-decoration-underline underline-offset-2px">
                   <i>
                     <a
                       href={article.statement.source.sourceUrl}
@@ -193,7 +193,7 @@ export function SingleStatementArticlePreview(props: {
 
           <p
             className={classNames({
-              'fs-12px fs-md-14px lh-md-base': isEmbedded,
+              'fs-12px fs-md-7 lh-md-base': isEmbedded,
               'fs-6 lh-sm': !isEmbedded,
             })}
           >


### PR DESCRIPTION
We can now use `fs-sm-7`, `fs-md-7`, and so on for the `fs-7`.

`fs-7` adjusted to be `0.875rem` (14px) and re-used everywhere the `fs-14px` or `fs-md-14` or `font-size: 14px` used to be.