### PR TITLE
Hide unsafe text generated by ck-editor

### DIFF
--- a/assets/styles/article/_redesign.scss
+++ b/assets/styles/article/_redesign.scss
@@ -2,6 +2,7 @@
 
 .article-redesign {
   @include perex;
+  @include unsafe-data-wrapper;
 
   .text-align-start {
     text-align: start;

--- a/assets/styles/mixins/_rich_text.scss
+++ b/assets/styles/mixins/_rich_text.scss
@@ -12,3 +12,9 @@
     }
   }
 }
+
+@mixin unsafe-data-wrapper {
+  [data-ck-unsafe-element="script"] {
+    display: none;
+  }
+}

--- a/assets/styles/statement/_redesign.scss
+++ b/assets/styles/statement/_redesign.scss
@@ -2,6 +2,7 @@
 
 .statement-detail {
   @include perex;
+  @include unsafe-data-wrapper;
 
   .radius-22px {
     border-radius: 22px;


### PR DESCRIPTION
Hides the generated element by using the attribute selector.

To reduce the amount of copy/pasted code between statement and article details I used SASS mixin and re-used it in both files.

<img width="1372" alt="Screenshot 2024-12-31 at 10 26 51" src="https://github.com/user-attachments/assets/feae34e6-6437-4644-abec-39143a431180" />

