### PR TITLE
Use new Notification.isRead field

### DIFF
--- a/components/admin/notifications/NotificationsTable.tsx
+++ b/components/admin/notifications/NotificationsTable.tsx
@@ -14,7 +14,7 @@ const NotificationsTableFragment = gql(`
         id
         fullText
         createdAt
-        readAt
+        isRead
         statement {
           content
           id
@@ -52,7 +52,7 @@ export function NotificationsTable(props: {
               key={edge.node.id}
               className={classNames(
                 'text-start hover:bg-gray-50 hover:text-indigo-600 cursor-pointer',
-                { 'bg-blue-100 hover:bg-gray-100': !edge.node.readAt }
+                { 'bg-blue-100 hover:bg-gray-100': !edge.node.isRead }
               )}
               onClick={() => edge.node && markAsReadAndRedirect(edge.node.id)}
             >

--- a/components/admin/notifications/ToggleReadButton.tsx
+++ b/components/admin/notifications/ToggleReadButton.tsx
@@ -12,7 +12,7 @@ import { SecondaryButton } from '../layout/buttons/SecondaryButton'
 const ToggleReadButtonFragment = gql(`
   fragment ToggleReadButton on Notification {
     id
-    readAt
+    isRead
   }
 `)
 
@@ -21,7 +21,8 @@ export function ToggleReadButton(props: {
 }) {
   const notification = useFragment(ToggleReadButtonFragment, props.notification)
 
-  const isRead = notification.readAt !== null
+  const { isRead } = notification
+
   const router = useRouter() // Force refresh the page
 
   const handleToggle = async (evt: React.MouseEvent<HTMLButtonElement>) => {


### PR DESCRIPTION
We introduced new `isRead: Boolean!` field to the GraphQL API. This PR changes the code so we use that field instead of readAt === null checks.