### PR TITLE
Veracity label and statement heading have the same size

### DIFF
--- a/app/(main)/statements/[slug]/page.tsx
+++ b/app/(main)/statements/[slug]/page.tsx
@@ -15,6 +15,7 @@ import StatementItem from '@/components/statement/Item'
 import { SourceSpeakerAvatar } from '@/components/statement/SourceSpeakerAvatar'
 import { StatementDisplayMode } from '@/libs/statements/display-mode'
 import TagIcon from '@/assets/icons/tag.svg'
+import { isStatefulPromise } from '@apollo/client/utilities'
 
 export async function generateMetadata(props: {
   params: { slug: string }
@@ -196,7 +197,7 @@ export default async function Statement(props: { params: { slug: string } }) {
             )}
           </div>
           <div className="assessment-veracity d-flex flex-column flex-md-row align-items-md-center justify-content-md-start mt-6 mt-md-10">
-            <div className="display-2 fw-bold me-md-6 flex-shrink-0">
+            <div className="fs-4 fw-bold me-md-6 flex-shrink-0">
               Tento výrok byl ověřen jako
             </div>
             <div className="d-flex align-items-center mt-2 mt-md-0">

--- a/components/statement/AssessmentVeracityIcon.tsx
+++ b/components/statement/AssessmentVeracityIcon.tsx
@@ -30,7 +30,7 @@ export function AssessmentVeracityIcon(props: {
         }
       )}
     >
-      <VeracityIcon type={assessment.veracity?.key} iconSize={11} />
+      <VeracityIcon type={assessment.veracity?.key} iconSize={13} />
     </span>
   )
 }

--- a/components/statement/AssessmentVeracityLabel.tsx
+++ b/components/statement/AssessmentVeracityLabel.tsx
@@ -20,7 +20,7 @@ export function AssessmentVeracityLabel(props: {
 
   return (
     <span
-      className={classNames('lh-1 text-uppercase fw-bold fs-6', {
+      className={classNames('lh-1 text-uppercase fw-bold fs-4', {
         'text-primary': assessment.veracity?.key === 'true',
         'text-secondary': assessment.veracity?.key === 'misleading',
         'text-red': assessment.veracity?.key === 'untrue',


### PR DESCRIPTION
<img width="518" alt="Screenshot 2025-01-10 at 11 33 42" src="https://github.com/user-attachments/assets/6fefaf02-1578-4206-8500-0c41fea31f3b" />

