### PR TITLE
Article source statements heading redesign

### DIFF
--- a/components/article/ArticleSegments.tsx
+++ b/components/article/ArticleSegments.tsx
@@ -115,21 +115,11 @@ export function ArticleSegments(props: ArticleStatementsProps) {
           )}
           {segment.segmentType === 'source_statements' && (
             <div>
-              <div className="row g-5 g-lg-10">
-                <div className="col-12">
-                  <h2
-                    className={classNames('fs-2 text-bold', {
-                      'mt-6': showPlayer,
-                    })}
-                  >
-                    {debateStats?.length ? (
-                      <>Řečníci s&nbsp;počty výroků dle hodnocení</>
-                    ) : (
-                      'Výroky'
-                    )}
-                  </h2>
-                </div>
-
+              <div
+                className={classNames('row g-5 g-lg-10', {
+                  'mt-1': showPlayer,
+                })}
+              >
                 {debateStats?.map((debateStat) => (
                   <div
                     key={debateStat.speaker?.id}

--- a/components/article/metadata/DebateArticleMetadata.tsx
+++ b/components/article/metadata/DebateArticleMetadata.tsx
@@ -16,7 +16,6 @@ const DebateArticleMetadataFragment = gql(`
         name
       }
     }
-    showPlayer
   }
 `)
 

--- a/components/article/metadata/DebateArticleMetadata.tsx
+++ b/components/article/metadata/DebateArticleMetadata.tsx
@@ -16,6 +16,7 @@ const DebateArticleMetadataFragment = gql(`
         name
       }
     }
+    showPlayer
   }
 `)
 
@@ -28,38 +29,25 @@ export function DebateArticleMetadata(props: {
     <>
       {article.articleType === 'default' && article.source && (
         <div className={classNames('mb-5 mb-lg-10 mt-8 mt-md-10')}>
-          <h2 className='"fs-2 text-uppercase text-primary'>Ověřili jsme</h2>
+          <h2 className='"fs-2 text-uppercase text-primary'>OVĚŘENO</h2>
           <div className="mt-4 fs-5">
-            {article.source.medium?.name}{' '}
-            {article.source?.releasedAt && (
-              <>ze dne {formatDate(article.source.releasedAt)}</>
-            )}
-            {((article.source.mediaPersonalities?.length ?? 0) > 0 ||
-              article.source.sourceUrl) && (
-              <>
-                {' '}
-                (
-                {article.source.mediaPersonalities?.length && (
-                  <>
-                    {article.source.mediaPersonalities.length ? (
-                      <>moderátoři </>
-                    ) : (
-                      <>moderátor </>
-                    )}
-                    {article.source.mediaPersonalities
-                      ?.map((mediaPersonality) => mediaPersonality.name)
-                      .join(', ')}
-                    {article.source.sourceUrl && ', '}
-                  </>
-                )}
-                {article.source.sourceUrl && (
-                  <a href={article.source.sourceUrl} className="ext">
-                    záznam
+            <h2 className="fs-2 text-bold">
+              <span className="text-decoration-underline">
+                {article.source.sourceUrl ? (
+                  <a href={article.source.sourceUrl}>
+                    {article.source.medium?.name}
                   </a>
+                ) : (
+                  article.source.medium?.name
                 )}
-                )
-              </>
-            )}
+              </span>
+
+              {article.source?.releasedAt && (
+                <span className="text-decoration-none">
+                  , {formatDate(article.source.releasedAt)}
+                </span>
+              )}
+            </h2>
           </div>
         </div>
       )}


### PR DESCRIPTION
Expected from the team: 
<img width="765" alt="Screenshot 2025-01-16 at 10 08 38" src="https://github.com/user-attachments/assets/452167f4-729e-4ac0-9f5f-569d748fd294" />

Actual result:
<img width="528" alt="Screenshot 2025-01-16 at 11 02 05" src="https://github.com/user-attachments/assets/ad324a43-feea-41ec-967c-d475fd94540b" />
