### PR TITLE
Fix issue with Map#keys returning an iterator

### DIFF
--- a/libs/sources/model/filters/FiltersFactory.ts
+++ b/libs/sources/model/filters/FiltersFactory.ts
@@ -39,7 +39,7 @@ export class FiltersFactory {
   }
 
   private getEvaluationStatusStatementFilters() {
-    return STATUS_FILTER_LABELS.keys().map(
+    return [...STATUS_FILTER_LABELS.keys()].map(
       (key) => new EvaluationStatusStatementFilter(key)
     )
   }


### PR DESCRIPTION
We used a map function on the iterator, but it's not supported on mobile Safari.