### PR TITLE
Removed margin top on first child of demagog-box-wrapper

### DIFF
--- a/assets/styles/statement/_redesign.scss
+++ b/assets/styles/statement/_redesign.scss
@@ -122,7 +122,7 @@
       @include figcaption;
     }
 
-    .ck-editor_demagog-box-wrapper > p:first-of-type {
+    .ck-editor_demagog-box-wrapper > :first-child {
       margin-top: 0 !important;
     }
 

--- a/assets/styles/tailwind.css
+++ b/assets/styles/tailwind.css
@@ -55,8 +55,12 @@
   /* CK Editor content and admin article detail styles */
   .ck .ck-content,
   .article-content {
+    .ck-editor_demagog-box-wrapper> :first-child {
+      @apply !mt-0;
+    }
+
     .ck-editor_demagog-box-wrapper>p:not(:first-of-type) {
-      @apply mt-3;
+      @apply mt-6;
     }
 
     .ck-editor_demagog-box-wrapper {
@@ -123,6 +127,7 @@
 
   .article-content,
   .ck-content {
+
     ul,
     ol {
       @apply !mt-8 !max-w-xl !space-y-4 !text-gray-600 px-3;


### PR DESCRIPTION
I also added a larger margin-top to the paragraphs in the demagog-box-wrapper in ck-editor because small margin might be confusing for our colleagues, as they tend to add extra paragraphs to create more spacing between them.