### PR TITLE
Exclude iframely from anchrome lib

### DIFF
--- a/libs/comments/text.ts
+++ b/libs/comments/text.ts
@@ -19,7 +19,12 @@ export const nicerLinks = (commentContent: string) =>
 export const nicerLinksNoTruncate = (text: string) =>
   anchorme({
     input: text,
-    options: { attributes: { name: 'target', value: '_blank' } },
+    options: {
+      attributes: { name: 'target', value: '_blank' },
+      exclude(link) {
+        return link.startsWith('cdn.iframe.ly')
+      },
+    },
   })
 
 export const newlinesToParagraphsAndBreaks = (


### PR DESCRIPTION
We added the `nicerLinksNoTruncate` function to the `ArticleSegment` component to make all the links open in a new browser tab, but it messed up the iframely.

Luckily there's a function that allows us excluding certain links.