### PR TITLE
Question mark font changed

### DIFF
--- a/assets/styles/article/_redesign.scss
+++ b/assets/styles/article/_redesign.scss
@@ -39,6 +39,7 @@
   .quote-mark {
     font-size: 4rem;
     line-height: 1;
+    font-family: '__Inter_7e0f30';
   }
 
   .fw-semibold {

--- a/assets/styles/statement/_redesign.scss
+++ b/assets/styles/statement/_redesign.scss
@@ -24,6 +24,7 @@
   .quote-mark {
     font-size: 4rem;
     line-height: 1;
+    font-family: '__Inter_7e0f30';
   }
 
   .quote + * {


### PR DESCRIPTION
I managed to change the quotation mark like this:
<img width="855" alt="Screenshot 2025-02-17 at 10 02 07" src="https://github.com/user-attachments/assets/8b78b91f-7587-494f-8240-f4c2d72e120b" />
 
But its still different than the one in figma:
![Screenshot 2025-02-17 at 10 05 20](https://github.com/user-attachments/assets/bf1276f7-9ca6-4307-b535-b3f242e517a9)
